### PR TITLE
bump to hyperx 1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,70 +7,19 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.config.os }}
-    env: ${{ matrix.config.env }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        config:
-          - {
-              os: "ubuntu-latest",
-              arch: "amd64",
-              args: "",
-              url: "https://github.com/casey/just/releases/download/v0.5.11/just-v0.5.11-x86_64-unknown-linux-musl.tar.gz",
-              name: "just",
-              pathInArchive: "just",
-              env: {},
-            }
-          - {
-              os: "ubuntu-latest",
-              arch: "aarch64",
-              args: "--target aarch64-unknown-linux-gnu",
-              url: "https://github.com/casey/just/releases/download/v0.5.11/just-v0.5.11-x86_64-unknown-linux-musl.tar.gz",
-              name: "just",
-              pathInArchive: "just",
-              env: { OPENSSL_DIR: "/usr/local/openssl-aarch64" },
-            }
-          - {
-              os: "macos-latest",
-              arch: "amd64",
-              args: "",
-              url: "https://github.com/casey/just/releases/download/v0.5.11/just-v0.5.11-x86_64-apple-darwin.tar.gz",
-              name: "just",
-              pathInArchive: "just",
-              env: {},
-            }
     steps:
       - uses: actions/checkout@v2
-      - uses: engineerd/configurator@v0.0.7
+      - uses: engineerd/configurator@v0.0.8
         with:
-          name: ${{ matrix.config.name }}
-          url: ${{ matrix.config.url }}
-          pathInArchive: ${{ matrix.config.pathInArchive }}
-      # hack(bacongobbler): install rustfmt to work around darwin toolchain issues
-      - name: "(macOS) install dev tools"
-        if: runner.os == 'macOS'
-        run: |
-          rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
-          rustup component add clippy --toolchain stable-x86_64-apple-darwin
-          rustup update stable
-      - name: setup for cross-compile builds
-        if: matrix.config.arch == 'aarch64'
-        run: |
-          sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          cd /tmp
-          git clone https://github.com/openssl/openssl
-          cd openssl
-          git checkout OpenSSL_1_1_1l
-          sudo mkdir -p $OPENSSL_DIR
-          ./Configure linux-aarch64 --prefix=$OPENSSL_DIR --openssldir=$OPENSSL_DIR shared
-          make CC=aarch64-linux-gnu-gcc
-          sudo make install
-          rustup target add aarch64-unknown-linux-gnu
+          name: just
+          url: https://github.com/casey/just/releases/download/v0.10.2/just-v0.10.2-x86_64-unknown-linux-musl.tar.gz
+          pathInArchive: just
       - name: Build
         run: |
-          just build ${{ matrix.config.args }}
+          just build
           just test
 
   windows-build:
@@ -82,10 +31,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - uses: engineerd/configurator@v0.0.5
+      - uses: engineerd/configurator@v0.0.8
         with:
           name: just
-          url: "https://github.com/casey/just/releases/download/v0.5.11/just-v0.5.11-x86_64-pc-windows-msvc.zip"
+          url: "https://github.com/casey/just/releases/download/v0.10.2/just-v0.10.2-x86_64-pc-windows-msvc.zip"
           pathInArchive: just.exe
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: engineerd/configurator@v0.0.8
         with:
           name: just
-          url: https://github.com/casey/just/releases/download/v0.10.2/just-v0.10.2-x86_64-unknown-linux-musl.tar.gz
+          url: https://github.com/casey/just/releases/download/0.10.2/just-0.10.2-x86_64-unknown-linux-musl.tar.gz
           pathInArchive: just
       - name: Build
         run: |
@@ -34,7 +34,7 @@ jobs:
       - uses: engineerd/configurator@v0.0.8
         with:
           name: just
-          url: "https://github.com/casey/just/releases/download/v0.10.2/just-v0.10.2-x86_64-pc-windows-msvc.zip"
+          url: "https://github.com/casey/just/releases/download/0.10.2/just-0.10.2-x86_64-pc-windows-msvc.zip"
           pathInArchive: just.exe
       - name: Build
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,15 +25,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -60,26 +51,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "bytes"
-version = "0.4.12"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -261,12 +236,12 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.5",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -292,22 +267,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -318,40 +282,40 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
- "bytes 1.1.0",
- "http 0.2.5",
+ "bytes",
+ "http",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.5",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -380,7 +344,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
@@ -389,19 +353,18 @@ dependencies = [
 
 [[package]]
 name = "hyperx"
-version = "0.13.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a94cbc2c6f63028e5736ca4e811ae36d3990059c384cbe68298c66728a9776"
+checksum = "82566a1ace7f56f604d83b7b2c259c78e243d99c565f23d7b4ae34466442c5a2"
 dependencies = [
- "base64 0.10.1",
- "bytes 0.4.12",
- "http 0.1.21",
+ "base64",
+ "bytes",
+ "http",
  "httparse",
+ "httpdate",
  "language-tags",
- "log",
  "mime",
- "percent-encoding 1.0.1",
- "time",
+ "percent-encoding 2.1.0",
  "unicase 2.6.0",
 ]
 
@@ -438,15 +401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,7 +427,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98328bb4f360e6b2ceb1f95645602c7014000ef0c3809963df8ad3a3a09f8d99"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "crypto-mac",
  "digest",
  "hmac",
@@ -655,6 +609,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,12 +763,12 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
+ "base64",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.5",
+ "http",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -865,7 +839,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "log",
  "ring",
  "sct",
@@ -1037,16 +1011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
- "bytes 1.1.0",
+ "bytes",
  "libc",
  "memchr",
  "mio",
@@ -1115,7 +1079,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -1405,8 +1369,7 @@ dependencies = [
 [[package]]
 name = "www-authenticate"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62efb8259cda4e4c732287397701237b78daa4c43edcf3e613c8503a6c07dd"
+source = "git+https://github.com/bacongobbler/www-authenticate?branch=hyperx-1.3-support#c9f816aefd50f983ff79fa182f547f704d60d9ea"
 dependencies = [
  "hyperx",
  "unicase 1.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,8 @@ dependencies = [
  "sha2",
  "tokio",
  "tracing",
- "www-authenticate",
+ "unicase 1.4.2",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -1364,14 +1365,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "www-authenticate"
-version = "0.3.0"
-source = "git+https://github.com/bacongobbler/www-authenticate?branch=hyperx-1.3-support#c9f816aefd50f983ff79fa182f547f704d60d9ea"
-dependencies = [
- "hyperx",
- "unicase 1.4.2",
- "url 1.7.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "autocfg"
@@ -52,15 +52,15 @@ checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes",
  "fnv",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -289,21 +289,21 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.6"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.5"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -315,7 +315,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -353,14 +353,13 @@ dependencies = [
 
 [[package]]
 name = "hyperx"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82566a1ace7f56f604d83b7b2c259c78e243d99c565f23d7b4ae34466442c5a2"
+checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
 dependencies = [
  "base64",
  "bytes",
  "http",
- "httparse",
  "httpdate",
  "language-tags",
  "mime",
@@ -438,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "language-tags"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -450,9 +449,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "log"
@@ -566,9 +565,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -586,9 +585,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg",
  "cc",
@@ -610,26 +609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pin-project"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,15 +622,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-hack"
@@ -667,9 +646,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -924,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",
@@ -988,9 +967,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1013,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1028,9 +1007,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1044,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1076,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 anyhow = "1.0"
+hyperx = "1.3"
 futures-util = "0.3"
-hyperx = "0.13"
 lazy_static = "1.4"
 regex = "1.3"
 reqwest = {version = "0.11", default-features = false, features = ["json", "stream"]}
@@ -41,8 +41,8 @@ serde_json = "1.0"
 sha2 = "0.9.2"
 tokio = {version = "1.0", features = ["macros", "fs"]}
 tracing = {version = "0.1", features = ['log']}
-www-authenticate = "0.3"
 jwt = "0.15"
+www-authenticate = { git = "https://github.com/bacongobbler/www-authenticate", branch = "hyperx-1.3-support" }
 
 [dev-dependencies]
 rstest = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
   "Kevin Flansburg <kevin.flansburg@gmail.com>",
 ]
 description = "An OCI implementation in Rust"
-edition = "2018"
+edition = "2021"
 keywords = [
   "oci",
   "containers",
@@ -42,7 +42,8 @@ sha2 = "0.9.2"
 tokio = {version = "1.0", features = ["macros", "fs"]}
 tracing = {version = "0.1", features = ['log']}
 jwt = "0.15"
-www-authenticate = { git = "https://github.com/bacongobbler/www-authenticate", branch = "hyperx-1.3-support" }
+unicase = "1"
+url = "1"
 
 [dev-dependencies]
 rstest = "0.11"

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ allow = [
     "LicenseRef-krator-derive",
     "CC0-1.0",
     "BSD-2-Clause",
+    "MPL-2.0"
 ]
 
 deny = [

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use crate::token_cache::{RegistryOperation, RegistryToken, RegistryTokenType, To
 use anyhow::{anyhow, Context};
 use futures_util::future;
 use futures_util::stream::StreamExt;
-use hyperx::header::Header;
+use hyperx::header::{Header, Raw};
 use reqwest::header::HeaderMap;
 use reqwest::{RequestBuilder, Url};
 use sha2::Digest;
@@ -296,7 +296,7 @@ impl Client {
             None => return Ok(()),
         };
 
-        let auth = WwwAuthenticate::parse_header(&dist_hdr.as_bytes().into())?;
+        let auth = WwwAuthenticate::parse_header(&Raw::from(dist_hdr.as_bytes()))?;
         // If challenge_opt is not set it means that no challenge was present, even though the header
         // was present.
         let challenge_opt = match auth.get::<BearerChallenge>() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tracing::{debug, trace, warn};
-use www_authenticate::{Challenge, ChallengeFields, RawChallenge, WwwAuthenticate};
+use crate::www_authenticate::{Challenge, ChallengeFields, RawChallenge, WwwAuthenticate};
 
 const MIME_TYPES_DISTRIBUTION_MANIFEST: &[&str] = &[
     "application/vnd.docker.distribution.manifest.v2+json",

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,7 @@ use crate::secrets::*;
 use crate::Reference;
 
 use crate::token_cache::{RegistryOperation, RegistryToken, RegistryTokenType, TokenCache};
+use crate::www_authenticate::{Challenge, ChallengeFields, RawChallenge, WwwAuthenticate};
 use anyhow::{anyhow, Context};
 use futures_util::future;
 use futures_util::stream::StreamExt;
@@ -24,7 +25,6 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tracing::{debug, trace, warn};
-use crate::www_authenticate::{Challenge, ChallengeFields, RawChallenge, WwwAuthenticate};
 
 const MIME_TYPES_DISTRIBUTION_MANIFEST: &[&str] = &[
     "application/vnd.docker.distribution.manifest.v2+json",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod reference;
 mod regexp;
 pub mod secrets;
 mod token_cache;
+mod www_authenticate;
 
 #[doc(inline)]
 pub use client::Client;

--- a/src/www_authenticate/README.md
+++ b/src/www_authenticate/README.md
@@ -1,0 +1,5 @@
+# www-authenticate
+
+Provides HTTP WWW-Authenticate header parser/printer support for hyper/hyperx.
+
+This code was copied from https://github.com/KeenS/www-authenticate, which is unlicensed.

--- a/src/www_authenticate/mod.rs
+++ b/src/www_authenticate/mod.rs
@@ -1,0 +1,1165 @@
+//! www-authenticate
+//! missing HTTP WWW-Authenticate header parser/printer for hyper
+
+use hyperx::header::{Formatter, Header, RawLike};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use unicase::UniCase;
+
+/// `WWW-Authenticate` header, defined in
+/// [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.1)
+///
+/// The `WWW-Authenticate` header field indicates the authentication
+/// scheme(s) and parameters applicable to the target resource.
+/// This MUST be contained in HTTP responses whose status is 401.
+///
+/// # ABNF
+/// ```plain
+/// WWW-Authenticate = 1#challenge
+/// ```
+///
+/// # Example values
+/// * `Basic realm="foo", charset="UTF-8"`
+/// * `Digest
+///    realm="http-auth@example.org",
+///    qop="auth, auth-int",
+///    algorithm=MD5,
+///    nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+///    opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"`
+///
+/// # Examples
+///
+/// ```
+/// # extern crate hyperx;
+/// # extern crate www_authenticate;
+/// # use hyperx::header::Headers;
+/// # use www_authenticate::{WwwAuthenticate, DigestChallenge, Qop,
+/// # Algorithm};
+/// # fn main(){
+/// let auth = WwwAuthenticate::new(
+///     DigestChallenge {
+///         realm: Some("http-auth@example.org".into()),
+///         qop: Some(vec![Qop::Auth, Qop::AuthInt]),
+///         algorithm: Some(Algorithm::Sha256),
+///         nonce: Some("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v".into()),
+///         opaque: Some("FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
+///                          .into()),
+///         domain: None,
+///         stale: None,
+///         userhash: None,
+/// });
+/// let mut headers = Headers::new();
+/// headers.set(auth);
+/// # }
+/// ```
+///
+/// ```
+/// # extern crate hyperx;
+/// # extern crate www_authenticate;
+/// # use hyperx::header::Headers;
+/// # use www_authenticate::{WwwAuthenticate, BasicChallenge};
+/// # fn main(){
+/// let auth = WwwAuthenticate::new(BasicChallenge{realm: "foo".into()});
+/// let mut headers = Headers::new();
+/// headers.set(auth);
+/// let auth = headers.get::<WwwAuthenticate>().unwrap();
+/// let basics = auth.get::<BasicChallenge>().unwrap();
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct WwwAuthenticate(HashMap<UniCase<CowStr>, Vec<RawChallenge>>);
+
+/// The challenge described in
+/// [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.1).
+/// Used in `WWW-Authenticate` header.
+pub trait Challenge: Clone {
+    fn challenge_name() -> &'static str;
+    fn from_raw(raw: RawChallenge) -> Option<Self>;
+    fn into_raw(self) -> RawChallenge;
+}
+
+impl WwwAuthenticate {
+    pub fn new<C: Challenge>(c: C) -> Self {
+        let mut auth = WwwAuthenticate(HashMap::new());
+        auth.set(c);
+        auth
+    }
+
+    pub fn new_from_raw(scheme: String, raw: RawChallenge) -> Self {
+        let mut auth = WwwAuthenticate(HashMap::new());
+        auth.set_raw(scheme, raw);
+        auth
+    }
+
+    /// find challenges and convert them into `C` if found.
+    pub fn get<C: Challenge>(&self) -> Option<Vec<C>> {
+        self.0
+            .get(&UniCase(CowStr(Cow::Borrowed(C::challenge_name()))))
+            .map(|m| m.iter().map(Clone::clone).flat_map(C::from_raw).collect())
+    }
+
+    /// find challenges and return it if found
+    pub fn get_raw(&self, name: &str) -> Option<&[RawChallenge]> {
+        self.0
+            .get(&UniCase(CowStr(Cow::Borrowed(unsafe {
+                mem::transmute::<&str, &'static str>(name)
+            }))))
+            .map(AsRef::as_ref)
+    }
+
+    /// set a challenge. This replaces existing challenges of the same name.
+    pub fn set<C: Challenge>(&mut self, c: C) -> bool {
+        self.0
+            .insert(
+                UniCase(CowStr(Cow::Borrowed(C::challenge_name()))),
+                vec![c.into_raw()],
+            )
+            .is_some()
+    }
+
+    /// set a challenge. This replaces existing challenges of the same name.
+    pub fn set_raw(&mut self, scheme: String, raw: RawChallenge) -> bool {
+        self.0
+            .insert(UniCase(CowStr(Cow::Owned(scheme))), vec![raw])
+            .is_some()
+    }
+
+    /// append a challenge. This appends existing challenges of the same name.
+    pub fn append<C: Challenge>(&mut self, c: C) {
+        self.0
+            .entry(UniCase(CowStr(Cow::Borrowed(C::challenge_name()))))
+            .or_insert(Vec::new())
+            .push(c.into_raw())
+    }
+
+    /// append a challenge. This appends existing challenges of the same name.
+    pub fn append_raw(&mut self, scheme: String, raw: RawChallenge) {
+        self.0
+            .entry(UniCase(CowStr(Cow::Owned(scheme))))
+            .or_insert(Vec::new())
+            .push(raw)
+    }
+
+    /// test if the challenge exists
+    pub fn has<C: Challenge>(&self) -> bool {
+        self.get::<C>().is_some()
+    }
+}
+
+impl fmt::Display for WwwAuthenticate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (scheme, values) in &self.0 {
+            for value in values.iter() {
+                // tail commas are allowed
+                write!(f, "{} {}, ", scheme, value)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Header for WwwAuthenticate {
+    fn header_name() -> &'static str {
+        "WWW-Authenticate"
+    }
+
+    fn parse_header<'a, T>(raw: &'a T) -> hyperx::Result<Self> where T: RawLike<'a> {
+        let mut map = HashMap::new();
+        for data in raw.iter() {
+            let stream = parser::Stream::new(data.as_ref());
+            loop {
+                let (scheme, challenge) = match stream.challenge() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        if stream.is_end() {
+                            break;
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                };
+                // TODO: treat the cases when a scheme is duplicated
+                map.entry(UniCase(CowStr(Cow::Owned(scheme))))
+                    .or_insert(Vec::new())
+                    .push(challenge);
+            }
+        }
+        Ok(WwwAuthenticate(map))
+    }
+
+    fn fmt_header(&self, f: &mut Formatter) -> fmt::Result {
+        f.fmt_line(self)
+    }
+}
+
+macro_rules! try_opt {
+    ($e:expr) => {
+        match $e {
+            Some(e) => e,
+            None => return None,
+        }
+    };
+}
+
+#[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+struct CowStr(Cow<'static, str>);
+
+impl Deref for CowStr {
+    type Target = Cow<'static, str>;
+
+    fn deref(&self) -> &Cow<'static, str> {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CowStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for CowStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl DerefMut for CowStr {
+    fn deref_mut(&mut self) -> &mut Cow<'static, str> {
+        &mut self.0
+    }
+}
+
+impl AsRef<str> for CowStr {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+pub use self::raw::*;
+mod raw {
+    use super::*;
+    use std::borrow::Cow;
+    use std::mem;
+    use unicase::UniCase;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Quote {
+        Always,
+        IfNeed,
+    }
+
+    /// A representation of the challenge fields
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct ChallengeFields(HashMap<UniCase<CowStr>, (String, Quote)>);
+
+    impl ChallengeFields {
+        pub fn new() -> Self {
+            ChallengeFields(HashMap::new())
+        }
+        // fn values(&self) -> Values<K, V>
+        // fn values_mut(&mut self) -> ValuesMut<K, V>
+        // fn iter(&self) -> Iter<K, V>
+        // fn iter_mut(&mut self) -> IterMut<K, V>
+        // fn entry(&mut self, key: K) -> Entry<K, V>
+        pub fn len(&self) -> usize {
+            self.0.len()
+        }
+        pub fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+        // fn drain(&mut self) -> Drain<K, V>
+        pub fn clear(&mut self) {
+            self.0.clear()
+        }
+        pub fn get(&self, k: &str) -> Option<&String> {
+            self.0
+                .get(&UniCase(CowStr(Cow::Borrowed(unsafe {
+                    mem::transmute::<&str, &'static str>(k)
+                }))))
+                .map(|&(ref s, _)| s)
+        }
+        pub fn contains_key(&self, k: &str) -> bool {
+            self.0.contains_key(&UniCase(CowStr(Cow::Borrowed(unsafe {
+                mem::transmute::<&str, &'static str>(k)
+            }))))
+        }
+        pub fn get_mut(&mut self, k: &str) -> Option<&mut String> {
+            self.0
+                .get_mut(&UniCase(CowStr(Cow::Borrowed(unsafe {
+                    mem::transmute::<&str, &'static str>(k)
+                }))))
+                .map(|&mut (ref mut s, _)| s)
+        }
+        pub fn insert(&mut self, k: String, v: String) -> Option<String> {
+            self.0
+                .insert(UniCase(CowStr(Cow::Owned(k))), (v, Quote::IfNeed))
+                .map(|(s, _)| s)
+        }
+        pub fn insert_quoting(&mut self, k: String, v: String) -> Option<String> {
+            self.0
+                .insert(UniCase(CowStr(Cow::Owned(k))), (v, Quote::Always))
+                .map(|(s, _)| s)
+        }
+        pub fn insert_static(&mut self, k: &'static str, v: String) -> Option<String> {
+            self.0
+                .insert(UniCase(CowStr(Cow::Borrowed(k))), (v, Quote::IfNeed))
+                .map(|(s, _)| s)
+        }
+        pub fn insert_static_quoting(&mut self, k: &'static str, v: String) -> Option<String> {
+            self.0
+                .insert(UniCase(CowStr(Cow::Borrowed(k))), (v, Quote::Always))
+                .map(|(s, _)| s)
+        }
+        pub fn remove(&mut self, k: &str) -> Option<String> {
+            self.0
+                .remove(&UniCase(CowStr(Cow::Borrowed(unsafe {
+                    mem::transmute::<&str, &'static str>(k)
+                }))))
+                .map(|(s, _)| s)
+        }
+    }
+    // index
+
+    /// A representation of raw challenges. A Challenge is either a token or
+    /// fields.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum RawChallenge {
+        Token68(String),
+        Fields(ChallengeFields),
+    }
+
+    fn need_quote(s: &str, q: &Quote) -> bool {
+        if q == &Quote::Always {
+            true
+        } else {
+            s.bytes().any(|c| !parser::is_token_char(c))
+        }
+    }
+
+    impl fmt::Display for RawChallenge {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            use self::RawChallenge::*;
+            match *self {
+                Token68(ref token) => write!(f, "{}", token)?,
+                Fields(ref fields) => for (k, &(ref v, ref quote)) in fields.0.iter() {
+                    if need_quote(v, quote) {
+                        write!(f, "{}={:?}, ", k, v)?
+                    } else {
+                        write!(f, "{}={}, ", k, v)?
+                    }
+                },
+            }
+            Ok(())
+        }
+    }
+}
+
+pub use self::basic::*;
+mod basic {
+    use super::raw::RawChallenge;
+    use super::*;
+
+    /// The challenge for Basic authentication
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+    pub struct BasicChallenge {
+        /// realm of the authentication
+        pub realm: String,
+        // pub charset: Option<Charset>
+    }
+
+    impl Challenge for BasicChallenge {
+        fn challenge_name() -> &'static str {
+            "Basic"
+        }
+        fn from_raw(raw: RawChallenge) -> Option<Self> {
+            use self::RawChallenge::*;
+            match raw {
+                Token68(_) => return None,
+                Fields(mut map) => {
+                    let realm = try_opt!(map.remove("realm"));
+                    // only "UTF-8" is allowed.
+                    // See https://tools.ietf.org/html/rfc7617#section-2.1
+                    match map.remove("charset") {
+                        Some(c) => {
+                            if UniCase(&c) == UniCase("UTF-8") {
+                                ()
+                            } else {
+                                return None;
+                            }
+                        }
+                        None => (),
+                    }
+                    if !map.is_empty() {
+                        return None;
+                    }
+                    Some(BasicChallenge { realm })
+                }
+            }
+        }
+        fn into_raw(self) -> RawChallenge {
+            let mut map = ChallengeFields::new();
+            map.insert_static("realm", self.realm);
+            RawChallenge::Fields(map)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use hyperx::header::Raw;
+
+        #[test]
+        fn test_parse_basic() {
+            let input = "Basic realm=\"secret zone\"";
+            let auth = WwwAuthenticate::parse_header(&Raw::from(input)).unwrap();
+            let mut basics = auth.get::<BasicChallenge>().unwrap();
+            assert_eq!(basics.len(), 1);
+            let basic = basics.swap_remove(0);
+            assert_eq!(basic.realm, "secret zone")
+        }
+
+        #[test]
+        fn test_roundtrip_basic() {
+            let basic = BasicChallenge {
+                realm: "secret zone".into(),
+            };
+            let auth = WwwAuthenticate::new(basic.clone());
+            let data = format!("{}", auth);
+            let auth = WwwAuthenticate::parse_header(&Raw::from(data)).unwrap();
+            let basic_tripped = auth.get::<BasicChallenge>().unwrap().swap_remove(0);
+            assert_eq!(basic, basic_tripped);
+        }
+    }
+}
+
+pub use self::digest::*;
+mod digest {
+    use super::*;
+    use std::str::FromStr;
+    use url::Url;
+
+    /// The challenge for Digest authentication
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub struct DigestChallenge {
+        /// realm of the authentication
+        pub realm: Option<String>,
+        /// domains of the authentication
+        pub domain: Option<Vec<Url>>,
+        /// the nonce used in authentiaction
+        pub nonce: Option<String>,
+        /// a string data specified by the server
+        pub opaque: Option<String>,
+        /// a flag indicating that the previous request from
+        /// the client was rejected because the nonce value was stale.
+        pub stale: Option<bool>,
+        /// the algorithm used to produce the digest and unkeyed digest.
+        /// if not present, it is assumed to be Md5
+        pub algorithm: Option<Algorithm>,
+        /// "quality of protection" values supported by the server
+        pub qop: Option<Vec<Qop>>,
+        // pub charset: Option<Charset>,
+        /// this is an OPTIONAL parameter that is used by the server to
+        /// indicate that it supports username hashing.
+        /// default is false if not present
+        pub userhash: Option<bool>,
+    }
+
+    /// Algorithms used to produce the digest and unkeyed digest.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum Algorithm {
+        /// MD5
+        Md5,
+        /// MD5-sess
+        Md5Sess,
+        /// SHA-512-256
+        Sha512Trunc256,
+        /// SHA-512-256-sess
+        Sha512Trunc256Sess,
+        /// SHA-256
+        Sha256,
+        /// SHA-256-sess
+        Sha256Sess,
+        /// other algorithm
+        Other(String),
+    }
+
+    /// Quority of protection
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum Qop {
+        /// authentication
+        Auth,
+        /// authentication with integrity protection
+        AuthInt,
+    }
+
+    impl Challenge for DigestChallenge {
+        fn challenge_name() -> &'static str {
+            "Digest"
+        }
+        fn from_raw(raw: RawChallenge) -> Option<Self> {
+            use self::RawChallenge::*;
+            match raw {
+                Token68(_) => return None,
+                Fields(mut map) => {
+                    let realm = map.remove("realm");
+                    let domains = map.remove("domain");
+                    let nonce = map.remove("nonce");
+                    let opaque = map.remove("opaque");
+                    let stale = map.remove("stale");
+                    let algorithm = map.remove("algorithm");
+                    let qop = map.remove("qop");
+                    let charset = map.remove("charset");
+                    let userhash = map.remove("userhash");
+
+                    if !map.is_empty() {
+                        return None;
+                    }
+
+                    let domains = domains.and_then(|ds| {
+                        ds.split_whitespace()
+                            .map(Url::from_str)
+                            .map(::std::result::Result::ok)
+                            .collect::<Option<Vec<Url>>>()
+                    });
+                    let stale = stale.map(|s| s == "true");
+                    let algorithm = algorithm.map(|a| {
+                        use self::Algorithm::*;
+                        match a.as_str() {
+                            "MD5" => return Md5,
+                            "MD5-sess" => return Md5Sess,
+                            "SHA-512-256" => return Sha512Trunc256,
+                            "SHA-512-256-sess" => return Sha512Trunc256Sess,
+                            "SHA-256" => return Sha256,
+                            "SHA-256-sess" => return Sha256Sess,
+                            _ => (),
+                        };
+                        return Other(a);
+                    });
+                    let qop = match qop {
+                        None => None,
+                        Some(qop) => {
+                            let mut v = vec![];
+                            let s = parser::Stream::new(qop.as_bytes());
+                            loop {
+                                match try_opt!(s.token().ok()) {
+                                    "auth" => v.push(Qop::Auth),
+                                    "auth-int" => v.push(Qop::AuthInt),
+                                    _ => (),
+                                }
+                                try_opt!(s.skip_field_sep().ok());
+                                if s.is_end() {
+                                    break;
+                                }
+                            }
+                            Some(v)
+                        }
+                    };
+                    match charset {
+                        Some(c) => {
+                            if UniCase(&c) == UniCase("UTF-8") {
+                                ()
+                            } else {
+                                return None;
+                            }
+                        }
+                        None => (),
+                    }
+
+                    let userhash = userhash.and_then(|u| match u.as_str() {
+                        "true" => Some(true),
+                        "false" => Some(false),
+                        _ => None,
+                    });
+                    Some(DigestChallenge {
+                        realm,
+                        domain: domains,
+                        nonce,
+                        opaque,
+                        stale,
+                        algorithm,
+                        qop,
+                        // pub charset: Option<Charset>,
+                        userhash,
+                    })
+                }
+            }
+        }
+        fn into_raw(self) -> RawChallenge {
+            let mut map = ChallengeFields::new();
+            // Notes on quoting/non-quoting from the spec
+            // ttps://tools.ietf.org/html/rfc7616#section-3.3
+            //
+            // > For historical reasons, a sender MUST only generate the quoted string
+            // > syntax values for the following parameters: realm, domain, nonce,
+            // > opaque, and qop.
+            // >
+            // > For historical reasons, a sender MUST NOT generate the quoted string
+            // > syntax values for the following parameters: stale and algorithm.
+
+            for realm in self.realm {
+                map.insert_static_quoting("realm", realm);
+            }
+
+            for domain in self.domain {
+                let mut d = String::new();
+                d.extend(domain.into_iter().map(Url::into_string).map(|s| s + " "));
+                let len = d.len();
+                d.truncate(len - 1);
+                map.insert_static_quoting("domain", d);
+            }
+            for nonce in self.nonce {
+                map.insert_static_quoting("nonce", nonce);
+            }
+            for opaque in self.opaque {
+                map.insert_static_quoting("opaque", opaque);
+            }
+            for stale in self.stale {
+                map.insert_static("stale", format!("{}", stale));
+            }
+            for algorithm in self.algorithm {
+                map.insert_static("algorithm", format!("{}", algorithm));
+            }
+            for qop in self.qop {
+                let mut q = String::new();
+                q.extend(qop.into_iter().map(|q| format!("{}", q)).map(|s| s + ", "));
+                let len = q.len();
+                q.truncate(len - 2);
+                map.insert_static_quoting("qop", q);
+            }
+            for userhash in self.userhash {
+                map.insert_static("userhash", format!("{}", userhash));
+            }
+            RawChallenge::Fields(map)
+        }
+    }
+
+    impl fmt::Display for Algorithm {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            use self::Algorithm::*;
+            match *self {
+                Md5 => write!(f, "MD5"),
+                Md5Sess => write!(f, "MD5-sess"),
+                Sha512Trunc256 => write!(f, "SHA-512-256"),
+                Sha512Trunc256Sess => write!(f, "SHA-512-256-sess"),
+                Sha256 => write!(f, "SHA-256"),
+                Sha256Sess => write!(f, "SHA-256-sess"),
+                Other(ref s) => write!(f, "{}", s),
+            }
+        }
+    }
+
+    impl fmt::Display for Qop {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            use self::Qop::*;
+            match *self {
+                Auth => write!(f, "auth"),
+                AuthInt => write!(f, "auth-int"),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use hyperx::header::Raw;
+
+        #[test]
+        fn test_parse_digest() {
+            let input = r#"Digest realm="http-auth@example.org", qop="auth, auth-int", algorithm=SHA-256, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""#;
+            let auth = WwwAuthenticate::parse_header(&Raw::from(input)).unwrap();
+            let mut digests = auth.get::<DigestChallenge>().unwrap();
+            assert_eq!(digests.len(), 1);
+            let digest = digests.swap_remove(0);
+            assert_eq!(digest.realm, Some("http-auth@example.org".into()));
+            assert_eq!(digest.domain, None);
+            assert_eq!(
+                digest.nonce,
+                Some("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v".into())
+            );
+            assert_eq!(
+                digest.opaque,
+                Some("FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS".into())
+            );
+            assert_eq!(digest.stale, None);
+            assert_eq!(digest.algorithm, Some(Algorithm::Sha256));
+            assert_eq!(digest.qop, Some(vec![Qop::Auth, Qop::AuthInt]));
+            assert_eq!(digest.userhash, None);
+        }
+
+        #[test]
+        fn test_roundtrip_digest() {
+            let digest = DigestChallenge {
+                realm: Some("http-auth@example.org".into()),
+                domain: None,
+                nonce: Some("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v".into()),
+                opaque: Some("FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS".into()),
+                stale: None,
+                algorithm: Some(Algorithm::Sha256),
+                qop: Some(vec![Qop::Auth, Qop::AuthInt]),
+                userhash: None,
+            };
+            let auth = WwwAuthenticate::new(digest.clone());
+            let data = format!("{}", auth);
+            let auth = WwwAuthenticate::parse_header(&Raw::from(data)).unwrap();
+            let digest_tripped = auth.get::<DigestChallenge>().unwrap().swap_remove(0);
+            assert_eq!(digest, digest_tripped);
+        }
+    }
+}
+
+mod parser {
+    use super::raw::{ChallengeFields, RawChallenge};
+    use hyperx::{Error, Result};
+    use std::cell::Cell;
+    use std::str::from_utf8_unchecked;
+
+    pub struct Stream<'a>(Cell<usize>, &'a [u8]);
+
+    pub fn is_ws(c: u8) -> bool {
+        // See https://tools.ietf.org/html/rfc7230#section-3.2.3
+        b"\t ".contains(&c)
+    }
+
+    pub fn is_token_char(c: u8) -> bool {
+        // See https://tools.ietf.org/html/rfc7230#section-3.2.6
+        br#"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'*+-.^_`|~"#.contains(&c)
+    }
+
+    pub fn is_obs_text(c: u8) -> bool {
+        // See https://tools.ietf.org/html/rfc7230#section-3.2.6
+        // u8 is always under 0xFF
+        0x80 <= c
+    }
+
+    pub fn is_vchar(c: u8) -> bool {
+        // consult the ASCII definition
+        0x21 <= c && c <= 0x7E
+    }
+
+    pub fn is_qdtext(c: u8) -> bool {
+        // See https://tools.ietf.org/html/rfc7230#section-3.2.6
+        b"\t \x21".contains(&c) || (0x23 <= c && c <= 0x5B) || (0x5D <= 0x7E) || is_obs_text(c)
+    }
+
+    pub fn is_quoting(c: u8) -> bool {
+        b"\t ".contains(&c) || is_vchar(c) || is_obs_text(c)
+    }
+
+    impl<'a> Stream<'a> {
+        pub fn new(data: &'a [u8]) -> Self {
+            Stream(Cell::from(0), data)
+        }
+
+        pub fn inc(&self, i: usize) {
+            let pos = self.pos();
+            self.0.set(pos + i);
+        }
+
+        pub fn pos(&self) -> usize {
+            self.0.get()
+        }
+
+        pub fn is_end(&self) -> bool {
+            self.1.len() <= self.pos()
+        }
+
+        pub fn cur(&self) -> u8 {
+            self.1[self.pos()]
+        }
+
+        pub fn skip_a(&self, c: u8) -> Result<()> {
+            if self.cur() == c {
+                self.inc(1);
+                Ok(())
+            } else {
+                Err(Error::Header)
+            }
+        }
+        pub fn skip_a_next(&self, c: u8) -> Result<()> {
+            self.skip_ws()?;
+            if self.is_end() {
+                return Err(Error::Header);
+            }
+            self.skip_a(c)
+        }
+
+        pub fn take_while<F>(&self, f: F) -> Result<&[u8]>
+        where
+            F: Fn(u8) -> bool,
+        {
+            let start = self.pos();
+            while !self.is_end() && f(self.cur()) {
+                self.inc(1);
+            }
+            Ok(&self.1[start..self.pos()])
+        }
+
+        pub fn take_while1<F>(&self, f: F) -> Result<&[u8]>
+        where
+            F: Fn(u8) -> bool,
+        {
+            self.take_while(f).and_then(|b| {
+                if b.len() < 1 {
+                    Err(Error::Header)
+                } else {
+                    Ok(b)
+                }
+            })
+        }
+
+        pub fn r#try<F, T>(&self, f: F) -> Result<T>
+        where
+            F: FnOnce() -> Result<T>,
+        {
+            let init = self.pos();
+            match f() {
+                ok @ Ok(_) => ok,
+                err @ Err(_) => {
+                    self.0.set(init);
+                    err
+                }
+            }
+        }
+
+        pub fn skip_ws(&self) -> Result<()> {
+            self.take_while(is_ws).map(|_| ())
+        }
+
+        pub fn skip_next_comma(&self) -> Result<()> {
+            self.skip_a_next(b',')
+        }
+
+        pub fn skip_field_sep(&self) -> Result<()> {
+            self.skip_ws()?;
+            if self.is_end() {
+                return Ok(());
+            }
+            self.skip_next_comma()?;
+            while self.skip_next_comma().is_ok() {}
+            self.skip_ws()?;
+            Ok(())
+        }
+
+        pub fn token(&self) -> Result<&str> {
+            self.take_while1(is_token_char)
+                .map(|s| unsafe { from_utf8_unchecked(s) })
+        }
+
+        pub fn next_token(&self) -> Result<&str> {
+            self.skip_ws()?;
+            self.token()
+        }
+
+        pub fn quoted_string(&self) -> Result<String> {
+            // See https://tools.ietf.org/html/rfc7230#section-3.2.6
+            if self.is_end() {
+                return Err(Error::Header);
+            }
+
+            if self.cur() != b'"' {
+                return Err(Error::Header);
+            }
+            self.inc(1);
+            let mut s = Vec::new();
+            while !self.is_end() && self.cur() != b'"' {
+                if self.cur() == b'\\' {
+                    self.inc(1);
+                    if is_quoting(self.cur()) {
+                        s.push(self.cur());
+                        self.inc(1);
+                    } else {
+                        return Err(Error::Header);
+                    }
+                } else {
+                    if is_qdtext(self.cur()) {
+                        s.push(self.cur());
+                        self.inc(1);
+                    } else {
+                        return Err(Error::Header);
+                    }
+                }
+            }
+            if self.is_end() {
+                return Err(Error::Header);
+            } else {
+                debug_assert!(self.cur() == b'"');
+                self.inc(1);
+            }
+            String::from_utf8(s).map_err(|_| Error::Header)
+        }
+
+        pub fn token68(&self) -> Result<&str> {
+            let start = self.pos();
+            // See https://tools.ietf.org/html/rfc7235#section-2.1
+            self.take_while1(|c| {
+                b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-._~+/".contains(&c)
+            })?;
+            self.take_while(|c| c == b'=')?;
+            Ok(unsafe { from_utf8_unchecked(&self.1[start..self.pos()]) })
+        }
+
+        pub fn kv_token(&self) -> Result<(&str, &str)> {
+            let k = self.token()?;
+            self.skip_a_next(b'=')?;
+            self.skip_ws()?;
+            let v = self.token()?;
+            Ok((k, v))
+        }
+
+        pub fn kv_quoted(&self) -> Result<(&str, String)> {
+            let k = self.token()?;
+            self.skip_a_next(b'=')?;
+            self.skip_ws()?;
+            let v = self.quoted_string()?;
+            Ok((k, v))
+        }
+
+        pub fn field(&self) -> Result<(String, String)> {
+            self.r#try(|| self.kv_token().map(|(k, v)| (k.to_string(), v.to_string())))
+                .or_else(|_| self.kv_quoted().map(|(k, v)| (k.to_string(), v)))
+        }
+
+        pub fn raw_token68(&self) -> Result<RawChallenge> {
+            let ret = self.token68()
+                .map(ToString::to_string)
+                .map(RawChallenge::Token68)?;
+            self.skip_field_sep()?;
+            Ok(ret)
+        }
+
+        pub fn raw_fields(&self) -> Result<RawChallenge> {
+            let mut map = ChallengeFields::new();
+            loop {
+                match self.r#try(|| self.field()) {
+                    Err(_) => return Ok(RawChallenge::Fields(map)),
+                    Ok((k, v)) => {
+                        if self.skip_field_sep().is_ok() {
+                            if map.insert(k, v).is_some() {
+                                // field key must not be duplicated
+                                return Err(Error::Header);
+                            }
+                            if self.is_end() {
+                                return Ok(RawChallenge::Fields(map));
+                            }
+                        } else {
+                            return Err(Error::Header);
+                        }
+                    }
+                }
+            }
+        }
+
+        pub fn challenge(&self) -> Result<(String, RawChallenge)> {
+            let scheme = self.next_token()?;
+            self.take_while1(is_ws)?;
+            let challenge = self.r#try(|| self.raw_token68())
+                .or_else(|_| self.raw_fields())?;
+            Ok((scheme.to_string(), challenge))
+        }
+    }
+
+    #[test]
+    fn test_parese_quoted_field() {
+        let b = b"realm=\"secret zone\"";
+        let stream = Stream::new(b);
+        let (k, v) = stream.field().unwrap();
+        assert_eq!(k, "realm");
+        assert_eq!(v, "secret zone");
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_quoted_field_nonvchars() {
+        let b = b"realm=\"secret zone\t\xe3\x8a\x99\"";
+        let stream = Stream::new(b);
+        let (k, v) = stream.field().unwrap();
+        assert_eq!(k, "realm");
+        assert_eq!(v, "secret zone\t㊙");
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_token_field() {
+        let b = b"algorithm=MD5";
+        let stream = Stream::new(b);
+        let (k, v) = stream.field().unwrap();
+        assert_eq!(k, "algorithm");
+        assert_eq!(v, "MD5");
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_raw_quoted_fields() {
+        let b = b"realm=\"secret zone\"";
+        let stream = Stream::new(b);
+        match stream.raw_fields().unwrap() {
+            RawChallenge::Token68(_) => panic!(),
+            RawChallenge::Fields(fields) => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields.get("realm").unwrap(), "secret zone");
+            }
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_raw_token_fields() {
+        let b = b"algorithm=MD5";
+        let stream = Stream::new(b);
+        match stream.raw_fields().unwrap() {
+            RawChallenge::Token68(_) => panic!(),
+            RawChallenge::Fields(fields) => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields.get("algorithm").unwrap(), "MD5");
+            }
+        }
+        assert!(stream.is_end());
+    }
+    #[test]
+    fn test_parese_token68() {
+        let b = b"auea1./+=";
+        let stream = Stream::new(b);
+        let token = stream.token68().unwrap();
+        assert_eq!(token, "auea1./+=");
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_raw_token68() {
+        let b = b"auea1./+=";
+        let stream = Stream::new(b);
+        match stream.raw_token68().unwrap() {
+            RawChallenge::Token68(token) => assert_eq!(token, "auea1./+="),
+            RawChallenge::Fields(_) => panic!(),
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_challenge1() {
+        let b = b"Token abceaqj13-.+=";
+        let stream = Stream::new(b);
+        match stream.challenge().unwrap() {
+            (scheme, RawChallenge::Token68(token)) => {
+                assert_eq!(scheme, "Token");
+                assert_eq!(token, "abceaqj13-.+=");
+            }
+            (_, RawChallenge::Fields(_)) => panic!(),
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_challenge2() {
+        let b = b"Basic realm=\"secret zone\"";
+        let stream = Stream::new(b);
+        match stream.challenge().unwrap() {
+            (_, RawChallenge::Token68(_)) => panic!(),
+            (scheme, RawChallenge::Fields(fields)) => {
+                assert_eq!(scheme, "Basic");
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields.get("realm").unwrap(), "secret zone");
+            }
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_challenge3() {
+        let b = b"Bearer token=aeub8_";
+        let stream = Stream::new(b);
+        match stream.challenge().unwrap() {
+            (_, RawChallenge::Token68(_)) => panic!(),
+            (scheme, RawChallenge::Fields(fields)) => {
+                assert_eq!(scheme, "Bearer");
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields.get("token").unwrap(), "aeub8_");
+            }
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_challenge4() {
+        let b = b"Bearer token=aeub8_, user=\"fooo\"";
+        let stream = Stream::new(b);
+        match stream.challenge().unwrap() {
+            (_, RawChallenge::Token68(_)) => panic!(),
+            (scheme, RawChallenge::Fields(fields)) => {
+                assert_eq!(scheme, "Bearer");
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields.get("token").unwrap(), "aeub8_");
+                assert_eq!(fields.get("user").unwrap(), "fooo");
+            }
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    fn test_parese_challenge5() {
+        let b = b"Bearer user=\"fooo\",,, token=aeub8_,,";
+        let stream = Stream::new(b);
+        match stream.challenge().unwrap() {
+            (_, RawChallenge::Token68(_)) => panic!(),
+            (scheme, RawChallenge::Fields(fields)) => {
+                assert_eq!(scheme, "Bearer");
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields.get("token").unwrap(), "aeub8_");
+                assert_eq!(fields.get("user").unwrap(), "fooo");
+            }
+        }
+        assert!(stream.is_end());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_null() {
+        let b = b"";
+        let stream = Stream::new(b);
+        println!("{:?}", stream.challenge().unwrap());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use hyperx::header::Raw;
+
+    #[test]
+    fn test_www_authenticate_multiple_headers() {
+        let input1 = br#"Digest realm="http-auth@example.org", qop="auth, auth-int", algorithm=SHA-256, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""#.to_vec();
+        let input2 = br#"Digest realm="http-auth@example.org", qop="auth, auth-int", algorithm=MD5, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""#.to_vec();
+        let input = Raw::from(vec![input1, input2]);
+
+        let auth = WwwAuthenticate::parse_header(&input).unwrap();
+        let digests = auth.get::<DigestChallenge>().unwrap();
+        assert!(digests.contains(&DigestChallenge {
+            realm: Some("http-auth@example.org".into()),
+            qop: Some(vec![Qop::Auth, Qop::AuthInt]),
+            algorithm: Some(Algorithm::Sha256),
+            nonce: Some("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v".into()),
+            opaque: Some("FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS".into()),
+            domain: None,
+            stale: None,
+            userhash: None,
+        }));
+
+        assert!(digests.contains(&DigestChallenge {
+            realm: Some("http-auth@example.org".into()),
+            qop: Some(vec![Qop::Auth, Qop::AuthInt]),
+            algorithm: Some(Algorithm::Md5),
+            nonce: Some("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v".into()),
+            opaque: Some("FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS".into()),
+            domain: None,
+            stale: None,
+            userhash: None,
+        }));
+    }
+
+
+}

--- a/src/www_authenticate/mod.rs
+++ b/src/www_authenticate/mod.rs
@@ -166,7 +166,10 @@ impl Header for WwwAuthenticate {
         "WWW-Authenticate"
     }
 
-    fn parse_header<'a, T>(raw: &'a T) -> hyperx::Result<Self> where T: RawLike<'a> {
+    fn parse_header<'a, T>(raw: &'a T) -> hyperx::Result<Self>
+    where
+        T: RawLike<'a>,
+    {
         let mut map = HashMap::new();
         for data in raw.iter() {
             let stream = parser::Stream::new(data.as_ref());
@@ -345,13 +348,15 @@ mod raw {
             use self::RawChallenge::*;
             match *self {
                 Token68(ref token) => write!(f, "{}", token)?,
-                Fields(ref fields) => for (k, &(ref v, ref quote)) in fields.0.iter() {
-                    if need_quote(v, quote) {
-                        write!(f, "{}={:?}, ", k, v)?
-                    } else {
-                        write!(f, "{}={}, ", k, v)?
+                Fields(ref fields) => {
+                    for (k, &(ref v, ref quote)) in fields.0.iter() {
+                        if need_quote(v, quote) {
+                            write!(f, "{}={:?}, ", k, v)?
+                        } else {
+                            write!(f, "{}={}, ", k, v)?
+                        }
                     }
-                },
+                }
             }
             Ok(())
         }
@@ -726,7 +731,8 @@ mod parser {
 
     pub fn is_token_char(c: u8) -> bool {
         // See https://tools.ietf.org/html/rfc7230#section-3.2.6
-        br#"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'*+-.^_`|~"#.contains(&c)
+        br#"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'*+-.^_`|~"#
+            .contains(&c)
     }
 
     pub fn is_obs_text(c: u8) -> bool {
@@ -924,7 +930,8 @@ mod parser {
         }
 
         pub fn raw_token68(&self) -> Result<RawChallenge> {
-            let ret = self.token68()
+            let ret = self
+                .token68()
                 .map(ToString::to_string)
                 .map(RawChallenge::Token68)?;
             self.skip_field_sep()?;
@@ -956,7 +963,8 @@ mod parser {
         pub fn challenge(&self) -> Result<(String, RawChallenge)> {
             let scheme = self.next_token()?;
             self.take_while1(is_ws)?;
-            let challenge = self.r#try(|| self.raw_token68())
+            let challenge = self
+                .r#try(|| self.raw_token68())
                 .or_else(|_| self.raw_fields())?;
             Ok((scheme.to_string(), challenge))
         }
@@ -1160,6 +1168,4 @@ mod tests {
             userhash: None,
         }));
     }
-
-
 }

--- a/src/www_authenticate/mod.rs
+++ b/src/www_authenticate/mod.rs
@@ -29,46 +29,6 @@ use unicase::UniCase;
 ///    algorithm=MD5,
 ///    nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
 ///    opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"`
-///
-/// # Examples
-///
-/// ```
-/// # extern crate hyperx;
-/// # extern crate www_authenticate;
-/// # use hyperx::header::Headers;
-/// # use www_authenticate::{WwwAuthenticate, DigestChallenge, Qop,
-/// # Algorithm};
-/// # fn main(){
-/// let auth = WwwAuthenticate::new(
-///     DigestChallenge {
-///         realm: Some("http-auth@example.org".into()),
-///         qop: Some(vec![Qop::Auth, Qop::AuthInt]),
-///         algorithm: Some(Algorithm::Sha256),
-///         nonce: Some("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v".into()),
-///         opaque: Some("FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
-///                          .into()),
-///         domain: None,
-///         stale: None,
-///         userhash: None,
-/// });
-/// let mut headers = Headers::new();
-/// headers.set(auth);
-/// # }
-/// ```
-///
-/// ```
-/// # extern crate hyperx;
-/// # extern crate www_authenticate;
-/// # use hyperx::header::Headers;
-/// # use www_authenticate::{WwwAuthenticate, BasicChallenge};
-/// # fn main(){
-/// let auth = WwwAuthenticate::new(BasicChallenge{realm: "foo".into()});
-/// let mut headers = Headers::new();
-/// headers.set(auth);
-/// let auth = headers.get::<WwwAuthenticate>().unwrap();
-/// let basics = auth.get::<BasicChallenge>().unwrap();
-/// # }
-/// ```
 #[derive(Debug, Clone)]
 pub struct WwwAuthenticate(HashMap<UniCase<CowStr>, Vec<RawChallenge>>);
 


### PR DESCRIPTION
Needed to fix the `chrono`-related security issues - hyperx 0.13 was released back in January 2019.

Note: this is pending a change upstream to be [merged for hyperx 1.3 support](https://github.com/KeenS/www-authenticate/pull/5). Once that's merged I can stop cargo from pointing at my local git repository, which is necessary to publish oci-distribution.