### PR TITLE
Add support for manifest list/image index manifest

### DIFF
--- a/src/reference.rs
+++ b/src/reference.rs
@@ -81,6 +81,26 @@ pub struct Reference {
 }
 
 impl Reference {
+    /// Create a Reference with a registry, repository and tag.
+    pub fn with_tag(registry: String, repository: String, tag: String) -> Self {
+        Self {
+            registry,
+            repository,
+            tag: Some(tag),
+            digest: None,
+        }
+    }
+
+    /// Create a Reference with a registry, repository and digest.
+    pub fn with_digest(registry: String, repository: String, digest: String) -> Self {
+        Self {
+            registry,
+            repository,
+            tag: None,
+            digest: Some(digest),
+        }
+    }
+
     /// Resolve the registry address of a given `Reference`.
     ///
     /// Some registries, such as docker.io, uses a different address for the actual


### PR DESCRIPTION
This PR is an initial attempt to add support for manifest lists. (I wasn't sure whether to submit to here or krustlet/krustlet, so just picked here)

The approach I've gone for is:
- add OciImageIndexManifest struct representing an image manifest
- rename existing OciManifest to OciImageManifest
- create OciManifest enum wrapping the Image and Image Index manifest
- users can specify how a client behaves when it receives an image index manifest via the platform_resolver field
  - by default the client attempts to select an image from the image index manifest that matches the running platform
- the exception is the pull_manifest function - if someone is just pulling a manifest then they should get the manifest as it is in the registry
   - I've added a pull_image_manifest function which does attempt platform resolution

This approach gives users the ability to control how the client deals with image index manifests, without forcing users to deal with manifests on every image pull.

Obviously that's breaking, particularly the OciManifest struct- > enum switch. Though if this crate is to support manifest lists then I think OciManifest shouldn't be used to refer to image manifests specifically.


