### PR TITLE
Fix interacting with GitHub Container Registry

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1114,6 +1114,7 @@ mod test {
         HELLO_IMAGE_TAG_AND_DIGEST,
     ];
     const DOCKER_IO_IMAGE: &str = "docker.io/library/hello-world:latest";
+    const GHCR_IO_IMAGE: &str = "ghcr.io/krustlet/oci-distribution/hello-wasm:v1";
 
     #[test]
     fn test_apply_accept() -> Result<(), anyhow::Error> {
@@ -1889,5 +1890,16 @@ mod test {
             format!("{}", err),
             "unsupported media type: application/vnd.docker.distribution.manifest.list.v2+json"
         );
+    }
+
+    #[tokio::test]
+    async fn test_pull_ghcr_io() {
+        let reference = Reference::try_from(GHCR_IO_IMAGE).expect("failed to parse reference");
+        let mut c = Client::default();
+        let (manifest, _manifest_str) = c
+            .pull_manifest(&reference, &RegistryAuth::Anonymous)
+            .await
+            .unwrap();
+        assert_eq!(manifest.config.media_type, manifest::WASM_CONFIG_MEDIA_TYPE);
     }
 }


### PR DESCRIPTION
The GitHub container registry (ghcr.io) returns a bearer token that doesn't have an explicit expiration time.
    
Prior to this change, because of this anomaly, the token was not added into the JWT token cache. That caused all the request done against ghcr.io to be unauthenticated. That broke any kind of interaction with ghcr, even with public images.
    
This code handles the lack of an expiration claim by setting a 60 second expiration window.
According to [the official documentation](https://docs.docker.com/registry/spec/auth/token/#requesting-a-token), this behaviour is fine:
    
> The duration in seconds since the token was issued that it will remain valid.
> When omitted, this defaults to 60 seconds. For compatibility with older clients,
> a token should never be returned with less than 60 seconds to live.