### PR TITLE
Export pull_layer & auth API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -726,7 +726,7 @@ impl Client {
     /// repository and the registry, but it is not used to verify that
     /// the digest is a layer inside of the image. (The manifest is
     /// used for that.)
-    async fn pull_blob<T: AsyncWrite + Unpin>(
+    pub async fn pull_blob<T: AsyncWrite + Unpin>(
         &self,
         image: &Reference,
         digest: &str,

--- a/src/client.rs
+++ b/src/client.rs
@@ -325,7 +325,7 @@ impl Client {
     ///
     /// This performs authorization and then stores the token internally to be used
     /// on other requests.
-    async fn auth(
+    pub async fn auth(
         &mut self,
         image: &Reference,
         authentication: &RegistryAuth,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ mod token_cache;
 pub use client::Client;
 #[doc(inline)]
 pub use reference::{ParseError, Reference};
+#[doc(inline)]
+pub use token_cache::RegistryOperation;
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Export pull_blob API
    1. Container images will share layers, the API should support the scenario which don't need pull all the layers.
    2. Container image size may vary from megabyte to gigabyte, export pull_layer API can allow the user to the following layer decompress/unpack/store operations in parallel.

Export auth API
    For some container image service which support ondemand layer pull like:
        * stargz https://github.com/containerd/stargz-snapshotter
        * Nydus Image Service https://github.com/dragonflyoss/image-service
    export auth API is a requirement when token is expired.