### PR TITLE
Prepare `0.8.1` release

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Krustlet
-* @thomastaylor312 @bacongobbler @kflansburg @technosophos
+* @thomastaylor312 @bacongobbler @kflansburg @technosophos @flavio

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.8.0"
+version = "0.8.1"
 
 [badges]
 maintenance = {status = "actively-developed"}


### PR DESCRIPTION
Version bump to `0.8.1`

Tag a new release of oci-distribution. This is a patch release that contains the following fixes:

  * `ClientConfig`: define `accept_invalid_hostnames` attribute only when `native-tls` is being used
  * Improve parsing of container image names: this ensure `Reference` behaves in the same way as native Go libraries do when parsing oci names
  * Fix interactions with GitHub Container Registry: ensure anonymous operations (like `pull`) can be performed

The following cleanups have been done:

  * Remove `Cargo.lock` file from repository
  * Remove the in-tree version of the `www-authenticate` crate: use the latest official release of it, which contains all the changes and fixes oci-distribution did.
  * Fix all clippy warnings
  * Fix `cargo deny` execution