### PR TITLE
Fix the cargo deny failure

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,14 @@ license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
 
+[[licenses.clarify]]
+name = "encoding_rs"
+version = "*"
+expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x39f8ad31 }
+]
+
 [bans]
 skip = [
     # Pretty much all of these are for duplicate versions


### PR DESCRIPTION
Specify which license is used by the `encoding_rs` crate, this is required to fix the cargo deny checks.

Fixes https://github.com/krustlet/oci-distribution/issues/13