### PR TITLE
Remove manifest list from MIME Accept header

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -493,7 +493,7 @@ impl Client {
         debug!("Pulling image manifest from {}", url);
 
         let res = RequestBuilderWrapper::from_client(self, |client| client.get(&url))
-            .apply_accept(MIME_TYPES_DISTRIBUTION_MANIFEST)? // &[IMAGE_MANIFEST_MEDIA_TYPE]
+            .apply_accept(MIME_TYPES_DISTRIBUTION_MANIFEST)?
             .apply_auth(image, RegistryOperation::Pull)?
             .into_request_builder()
             .send()
@@ -507,7 +507,7 @@ impl Client {
                 let headers = res.headers().clone();
                 let text = res.text().await?;
                 let digest = digest_header_value(headers, Some(&text))?;
-
+                println!("{}", text);
                 self.validate_image_manifest(&text).await?;
 
                 debug!("Parsing response as OciManifest: {}", text);

--- a/src/client.rs
+++ b/src/client.rs
@@ -507,7 +507,7 @@ impl Client {
                 let headers = res.headers().clone();
                 let text = res.text().await?;
                 let digest = digest_header_value(headers, Some(&text))?;
-                println!("{}", text);
+
                 self.validate_image_manifest(&text).await?;
 
                 debug!("Parsing response as OciManifest: {}", text);


### PR DESCRIPTION
We pass a list of accepted MIME types when pulling manifests, but then we immediately reject anything other than `application/vnd.docker.distribution.manifest.v2+json` when validating the response on:
https://github.com/krustlet/oci-distribution/blob/0e5373e99c910ffd1261ace7e1b732036dc7784a/src/client.rs#L548

This change removes the list type which we are incapable of parsing. As a result, registries which can serve manifest lists (like DockerHub) will return a single manifest instead (presumably for `amd64`?). If we have a strong opinion in the future about which manifest to use from the list, we can implement proper parsing for these manifest lists. 