### PR TITLE
Minor fixes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -636,6 +636,7 @@ impl Client {
         }
         if let Some(media_type) = versioned.media_type {
             if media_type != IMAGE_MANIFEST_MEDIA_TYPE
+                && media_type != OCI_IMAGE_MEDIA_TYPE
                 && media_type != IMAGE_MANIFEST_LIST_MEDIA_TYPE
             {
                 return Err(anyhow::anyhow!("unsupported media type: {}", media_type));

--- a/src/client.rs
+++ b/src/client.rs
@@ -1102,7 +1102,10 @@ impl Default for ClientConfig {
     }
 }
 
-type PlatformResolverFn = dyn Fn(&[ImageIndexEntry]) -> Option<String>;
+// Be explicit about the traits supported by this type. This is needed to use
+// the Client behind a dynamic reference.
+// Something similar to what is described here: https://users.rust-lang.org/t/how-to-send-function-closure-to-another-thread/43549
+type PlatformResolverFn = dyn Fn(&[ImageIndexEntry]) -> Option<String> + Send + Sync;
 
 /// A platform resolver that chooses the first linux/amd64 variant, if present
 pub fn linux_amd64_resolver(manifests: &[ImageIndexEntry]) -> Option<String> {


### PR DESCRIPTION
Two minor fixes, each one living inside of its dedicated commit.

* Client: do not fail when a OCI manifest is found. The library is able to handle OCI manifests, hence it should not report an error when one is found.
* Fix usage of Client behind dynamic reference. Be explicit about the traits supported by the platform resolver function. This is needed to use the Client behind a dynamic reference, something similar to what is described [here](https://users.rust-lang.org/t/how-to-send-function-closure-to-another-thread/43549)

