### PR TITLE
fix: Allow build with feature `rustls-tls`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1093,7 +1093,7 @@ impl Default for ClientConfig {
     fn default() -> Self {
         Self {
             protocol: ClientProtocol::default(),
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(feature = "native-tls")]
             accept_invalid_hostnames: false,
             accept_invalid_certificates: false,
             extra_root_certificates: Vec::new(),


### PR DESCRIPTION
This change maintains the previous behaviour on Windows, but I'mt not
sure that is correct to be fair, and I suspect we only need:

`#[cfg(feature = "native-tls")]`