### PR TITLE
Remove digest calculation of ImageData

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -50,27 +50,6 @@ pub struct ImageData {
     pub manifest: Option<OciImageManifest>,
 }
 
-impl ImageData {
-    /// Helper function to compute the digest of the image layers
-    pub fn sha256_digest(&self) -> String {
-        sha256_digest(
-            &self
-                .layers
-                .iter()
-                .cloned()
-                .map(|l| l.data)
-                .flatten()
-                .collect::<Vec<u8>>(),
-        )
-    }
-
-    /// Returns the image digest, either the value in the field or by computing it
-    /// If the value in the field is None, the computed value will be stored
-    pub fn digest(&self) -> String {
-        self.digest.clone().unwrap_or_else(|| self.sha256_digest())
-    }
-}
-
 /// The data returned by an OCI registry after a successful push
 /// operation is completed
 pub struct PushResponse {


### PR DESCRIPTION
it previously calculated the digest of the image layers, by taking a digest of all the layers data. This calculation is not used in the OCI registry API, nor is the digest of an image.

(I intended to make this change in https://github.com/krustlet/oci-distribution/pull/22, as described in that PR description, but I didn't actually make the change...)