### PR TITLE
Push manifest list rebase and feedback addressed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ rstest = "0.11"
 hmac = "0.11"
 tracing-subscriber = "0.3.7"
 testcontainers = "0.12.0"
+tokio = {version = "1.0", features = ["macros", "fs", "rt-multi-thread"]}

--- a/examples/get-manifest/main.rs
+++ b/examples/get-manifest/main.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+extern crate oci_distribution;
+
+#[tokio::main]
+pub async fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Image ref not provided");
+        std::process::exit(1);
+    }
+
+    let reference: oci_distribution::Reference =
+        args[1].parse().expect("Not a valid OCI image reference");
+    let anon_auth = oci_distribution::secrets::RegistryAuth::Anonymous;
+
+    let mut client = oci_distribution::Client::default();
+    let (manifest, _) = client
+        .pull_manifest(&reference, &anon_auth)
+        .await
+        .expect("Cannot pull manifest");
+
+    println!("{}", manifest);
+}


### PR DESCRIPTION
This PR is based on https://github.com/krustlet/oci-distribution/pull/26. These are the changes done on top of what has been provided by @jsoverson:

* Rebase against `main` and fix the conflicts
* `OciManifest`: do not implement `Display` by serializing to JSON all the structs. This change was requested by @thomastaylor312 and @bacongobbler 
* Provide a simple example program that can be used to get an OCI manifest and display it on the stdout