### PR TITLE
Workaround AWS ECR issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,10 @@ olpc-cjson = "0.1.1"
 
 [dev-dependencies]
 anyhow = "1.0"
+clap = { version = "3.1.0", features = ["derive"] }
 rstest = "0.11"
+docker_credential = "1.0"
 hmac = "0.11"
-tracing-subscriber = "0.3.7"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 testcontainers = "0.12.0"
 tokio = {version = "1.0", features = ["macros", "fs", "rt-multi-thread"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ www-authenticate = "0.4.0"
 olpc-cjson = "0.1.1"
 
 [dev-dependencies]
+async-std = "1.11.0"
 anyhow = "1.0"
 clap = { version = "3.1.0", features = ["derive"] }
 rstest = "0.11"

--- a/examples/pull-wasm/main.rs
+++ b/examples/pull-wasm/main.rs
@@ -1,0 +1,104 @@
+extern crate oci_distribution;
+use oci_distribution::{manifest, secrets::RegistryAuth, Client, Reference};
+
+use clap::Parser;
+use docker_credential::{CredentialRetrievalError, DockerCredential};
+use tracing::{debug, info, warn};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{fmt, EnvFilter};
+
+/// Pull a WebAssembly module from a OCI container registry
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    /// Enable verbose mode
+    #[clap(short, long)]
+    verbose: bool,
+
+    /// Perform anonymous operation, by default the tool tries to reuse the docker credentials read
+    /// from the default docker file
+    #[clap(short, long)]
+    anonymous: bool,
+
+    /// Pull image from registry using HTTP instead of HTTPS
+    #[clap(short, long)]
+    insecure: bool,
+
+    /// Write contents to file
+    #[clap(short, long)]
+    output: String,
+
+    /// Name of the image to pull
+    image: String,
+}
+
+fn build_auth(reference: &Reference, cli: &Cli) -> RegistryAuth {
+    let server = reference
+        .resolve_registry()
+        .strip_suffix("/")
+        .unwrap_or_else(|| reference.resolve_registry());
+
+    if cli.anonymous {
+        return RegistryAuth::Anonymous;
+    }
+
+    match docker_credential::get_credential(server) {
+        Err(CredentialRetrievalError::ConfigNotFound) => RegistryAuth::Anonymous,
+        Err(e) => panic!("Error handling docker configuration file: {}", e),
+        Ok(DockerCredential::UsernamePassword(username, password)) => {
+            debug!("Found docker credentials");
+            RegistryAuth::Basic(username, password)
+        }
+        Ok(DockerCredential::IdentityToken(_)) => {
+            warn!("Cannot use contents of docker config, identity token not supported. Using anonymous auth");
+            RegistryAuth::Anonymous
+        }
+    }
+}
+
+fn build_client_config(cli: &Cli) -> oci_distribution::client::ClientConfig {
+    let protocol = if cli.insecure {
+        oci_distribution::client::ClientProtocol::Http
+    } else {
+        oci_distribution::client::ClientProtocol::Https
+    };
+
+    oci_distribution::client::ClientConfig {
+        protocol,
+        ..Default::default()
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    let cli = Cli::parse();
+
+    // setup logging
+    let level_filter = if cli.verbose { "debug" } else { "info" };
+    let filter_layer = EnvFilter::new(level_filter);
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .init();
+
+    let client_config = build_client_config(&cli);
+    let mut client = Client::new(client_config);
+
+    let reference: Reference = cli.image.parse().expect("Not a valid image reference");
+    info!(?reference, "fetching wasm module");
+
+    let auth = build_auth(&reference, &cli);
+
+    let image_content = client
+        .pull(&reference, &auth, vec![manifest::WASM_LAYER_MEDIA_TYPE])
+        .await
+        .expect("Cannot pull Wasm module")
+        .layers
+        .into_iter()
+        .next()
+        .map(|layer| layer.data)
+        .expect("No data found");
+
+    std::fs::write(&cli.output, image_content).expect("Cannot write to file");
+    println!("Wasm module successfully written to {}", &cli.output);
+}

--- a/examples/wasm/cli.rs
+++ b/examples/wasm/cli.rs
@@ -1,0 +1,35 @@
+use clap::{Parser, Subcommand};
+
+/// Pull a WebAssembly module from a OCI container registry
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub(crate) struct Cli {
+    /// Enable verbose mode
+    #[clap(short, long)]
+    pub verbose: bool,
+
+    /// Perform anonymous operation, by default the tool tries to reuse the docker credentials read
+    /// from the default docker file
+    #[clap(short, long)]
+    pub anonymous: bool,
+
+    /// Pull image from registry using HTTP instead of HTTPS
+    #[clap(short, long)]
+    pub insecure: bool,
+
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum Commands {
+    #[clap(arg_required_else_help = true)]
+    Pull {
+        /// Write contents to file
+        #[clap(short, long)]
+        output: String,
+
+        /// Name of the image to pull
+        image: String,
+    },
+}

--- a/examples/wasm/cli.rs
+++ b/examples/wasm/cli.rs
@@ -32,4 +32,12 @@ pub(crate) enum Commands {
         /// Name of the image to pull
         image: String,
     },
+    #[clap(arg_required_else_help = true)]
+    Push {
+        /// Wasm file to push
+        module: String,
+
+        /// Name of the image to pull
+        image: String,
+    },
 }

--- a/examples/wasm/pull.rs
+++ b/examples/wasm/pull.rs
@@ -1,0 +1,24 @@
+use oci_distribution::{manifest, secrets::RegistryAuth, Client, Reference};
+use tracing::info;
+
+pub(crate) async fn pull_wasm(
+    client: &mut Client,
+    auth: &RegistryAuth,
+    reference: &Reference,
+    output: &str,
+) {
+    info!(?reference, ?output, "pulling wasm module");
+
+    let image_content = client
+        .pull(reference, auth, vec![manifest::WASM_LAYER_MEDIA_TYPE])
+        .await
+        .expect("Cannot pull Wasm module")
+        .layers
+        .into_iter()
+        .next()
+        .map(|layer| layer.data)
+        .expect("No data found");
+
+    std::fs::write(output, image_content).expect("Cannot write to file");
+    println!("Wasm module successfully written to {}", output);
+}

--- a/examples/wasm/pull.rs
+++ b/examples/wasm/pull.rs
@@ -19,6 +19,8 @@ pub(crate) async fn pull_wasm(
         .map(|layer| layer.data)
         .expect("No data found");
 
-    std::fs::write(output, image_content).expect("Cannot write to file");
+    async_std::fs::write(output, image_content)
+        .await
+        .expect("Cannot write to file");
     println!("Wasm module successfully written to {}", output);
 }

--- a/examples/wasm/push.rs
+++ b/examples/wasm/push.rs
@@ -14,7 +14,9 @@ pub(crate) async fn push_wasm(
 ) {
     info!(?reference, ?module, "pushing wasm module");
 
-    let data = std::fs::read(module).expect("Cannot read Wasm module from disk");
+    let data = async_std::fs::read(module)
+        .await
+        .expect("Cannot read Wasm module from disk");
 
     let layers = vec![ImageLayer::new(
         data,

--- a/examples/wasm/push.rs
+++ b/examples/wasm/push.rs
@@ -1,0 +1,36 @@
+use oci_distribution::{
+    client::{Config, ImageLayer},
+    manifest,
+    secrets::RegistryAuth,
+    Client, Reference,
+};
+use tracing::info;
+
+pub(crate) async fn push_wasm(
+    client: &mut Client,
+    auth: &RegistryAuth,
+    reference: &Reference,
+    module: &str,
+) {
+    info!(?reference, ?module, "pushing wasm module");
+
+    let data = std::fs::read(module).expect("Cannot read Wasm module from disk");
+
+    let layers = vec![ImageLayer::new(
+        data,
+        manifest::WASM_LAYER_MEDIA_TYPE.to_string(),
+    )];
+
+    let config = Config {
+        data: b"{}".to_vec(),
+        media_type: manifest::WASM_CONFIG_MEDIA_TYPE.to_string(),
+    };
+
+    let response = client
+        .push(&reference, &layers, config, &auth, None)
+        .await
+        .map(|push_response| push_response.manifest_url)
+        .expect("Cannot push Wasm module");
+
+    println!("Wasm module successfully pushed {:?}", response);
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -616,6 +616,9 @@ impl Client {
                     .map_err(|e| OciDistributionError::ManifestParsingError(e.to_string()))?;
                 Ok((manifest, digest))
             }
+            reqwest::StatusCode::UNAUTHORIZED => {
+                Err(OciDistributionError::UnauthorizedError { url })
+            }
             s if s.is_client_error() => {
                 // According to the OCI spec, we should see an error in the message body.
                 let envelope = res.json::<OciEnvelope>().await?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,9 +32,9 @@ pub enum OciDistributionError {
     /// Manifest: JSON unmarshalling error
     #[error("Failed to parse manifest as Versioned object: {0}")]
     ManifestParsingError(String),
-    /// Cannot push chunk without data
-    #[error("cannot push a chunk without data")]
-    PushChunkNoDataError,
+    /// Cannot push a blob without data
+    #[error("cannot push a blob without data")]
+    PushNoDataError,
     /// Cannot push layer object without data
     #[error("cannot push a layer without data")]
     PushLayerNoDataError,
@@ -71,6 +71,10 @@ pub enum OciDistributionError {
         /// Error message returned by the remote server
         message: String,
     },
+    /// The [OCI distribution spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+    /// is not respected by the remote registry
+    #[error("OCI distribution spec violation: {0}")]
+    SpecViolationError(String),
     /// HTTP auth failed - user not authorized
     #[error("Not authorized: url {url}")]
     UnauthorizedError {


### PR DESCRIPTION
Workaround push issues affecting AWS ECR
    
It seems AWS ECR is not respecting the OCI Distribution Spefication about:

* Push blobs as chunks: successful chunk uploads have return code 201 instead of 202
* Push Manifest: successful response is missing the `Location` header

This PR tries to work around this limitations, until the issues are sorted out by AWS.

These are the mitigations used.

* Wrong response with chunked uploads: when a spec violation is found, attempt the upload using the monolithic approach. ECR is respecting the spec in that regard.
* Missing `Location` header after manifest upload: given the whole image is already inside of the remote registry, we calculate the `Location` value by using the digest of the manifest. This is the value that is expect to be returned by the remote registry.

In both cases, warning messages are emitted to inform the user about the violations.

This PR introduces also some example programs that can be used to push and pull Wasm modules to/from OCI registry.

~~Note well: this PR is based on top of https://github.com/krustlet/oci-distribution/pull/31~~ Update: the PR got merged
