### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.8.1"
+version = "0.9.0"
 
 [badges]
 maintenance = {status = "actively-developed"}


### PR DESCRIPTION
Changes since 0.8.1:

* Add support for manifest list and image index manifest types
* Fix: address Windows incompatibility issues
* [API breaking] Change the API of `Client::push`: return also the manifest digest
* Fix: do not fail when an OCI manifest is returned. The library can handle them too
* Fix: Be explicit about the traits supported by the platform resolver function. This is needed to use the Client behind a dynamic reference.
* [API breaking] Fix: pushing of images with multiple layers now works
* Enhancement: ensure the manifest pushed are using canonicalized JSON
* Enhancement: improve test suite by performing certain operations against a real container registry
* Enhancement: export the `pull_layer` and the auth APIs
* Enhancement: support of pushing manifest lists
* [API breaking] Enhancement: get rid of `anyhow::Result`, instead provide specific error types defined inside of the library
* Enhancement: workaround AWS ECR issues. The registry is not compliant with the OCI distribution specification. Work around these issues
  instead of refusing to work with this type of registries.
* [API breaking] fix/enhancement: better handling of OCI image annotations