### PR TITLE
Fix workaround used when pushing to ECR

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -972,7 +972,13 @@ impl Client {
             // AWS ECR are violating this aspect of the spec. This at least let the
             // oci-distribution users interact with these registries.
             warn!("Registry is not respecting the OCI Distribution Specification: it didn't return the Location of the uploaded Manifest inside of the response headers. Working around this issue...");
-            return Ok(manifest_hash);
+
+            let url_base = url
+                .strip_suffix(image.tag().unwrap_or("latest"))
+                .expect("The manifest URL always ends with the image tag suffix");
+            let url_by_digest = format!("{}{}", url_base, manifest_hash);
+
+            return Ok(url_by_digest);
         }
 
         ret


### PR DESCRIPTION
ECR currently doesn't properly follow the OCI distribution specification. Because of that, we had to implement a workaround when
performing manifest push.

Prior to this commit, the push manifest function returned the supposed digest of the OCI manifest when pushing to an ECR. However, the function was expected to return the URL to the immutable manifest location.

This commit fixes the behaviour of the workaround code, making it return a proper URL instead of just the manifest digest.