### PR TITLE
Allow to use trust-dns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ maintenance = {status = "actively-developed"}
 default = ["native-tls", "test-registry"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+trust-dns = ["reqwest/trust-dns"]
 # This features is used by tests that use docker to create a registry
 test-registry = []
 

--- a/deny.toml
+++ b/deny.toml
@@ -16,14 +16,14 @@ default = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
+    "BSD-2-Clause",
+    "LicenseRef-krator",
+    "LicenseRef-krator-derive",
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "LicenseRef-webpki-roots",
-    "LicenseRef-krator",
-    "LicenseRef-krator-derive",
-    "CC0-1.0",
-    "BSD-2-Clause",
-    "MPL-2.0"
+    "MPL-2.0",
+    "Unicode-DFS-2016",
 ]
 
 deny = [

--- a/src/client.rs
+++ b/src/client.rs
@@ -747,7 +747,7 @@ impl Client {
         auth: &RegistryAuth,
         manifest: OciImageIndex,
     ) -> Result<String> {
-        let _response = self.auth(reference, auth, RegistryOperation::Push).await?;
+        self.auth(reference, auth, RegistryOperation::Push).await?;
         self.push_manifest(reference, &OciManifest::ImageIndex(manifest))
             .await
     }
@@ -1334,7 +1334,7 @@ pub fn current_platform_resolver(manifests: &[ImageIndexEntry]) -> Option<String
 }
 
 /// The protocol that the client should use to connect
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClientProtocol {
     #[allow(missing_docs)]
     Http,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -138,7 +138,7 @@ impl std::fmt::Display for OciEnvelope {
 /// OCI error codes
 ///
 /// Outlined [here](https://github.com/opencontainers/distribution-spec/blob/master/spec.md#errors-2)
-#[derive(serde::Deserialize, Debug, PartialEq)]
+#[derive(serde::Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OciErrorCode {
     /// Blob unknown to registry


### PR DESCRIPTION
Add options to oci-distrobution to use
non local DNS, mainly for when
running embedded in a docker container.
