### PR TITLE
fix: address broken test

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2197,10 +2197,11 @@ mod test {
             ..Default::default()
         });
 
+        // pulling webassembly.azurecr.io/hello-wasm:v1
         let image: Reference = HELLO_IMAGE_TAG_AND_DIGEST.parse().unwrap();
-        c.auth(&image, &registry_auth, RegistryOperation::Pull)
+        c.auth(&image, &RegistryAuth::Anonymous, RegistryOperation::Pull)
             .await
-            .expect("authenticated");
+            .expect("cannot authenticate against registry for pull operation");
 
         let (manifest, _digest) = c
             ._pull_image_manifest(&image)


### PR DESCRIPTION
Fix one of our unit test that suddenly started to fail.

The test was doing to following operations:

1. Start local OCI registry configured to require authentication
2. Pull a wasm module from the public Azure Container Registry
3. Push the wasm module into the local OCI registry

The test was using the local OCI registry credentials to authenticate against the Azure Container Registry. This was not needed because the module being pulled is public, hence no auth is required. Something changed with regards to Azure CR, which started to reject our authentication efforts.

The test has been changed to perform an anonymous pull from Azure CR.
