### PR TITLE
fix: rustls allow usage or system root certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ maintenance = {status = "actively-developed"}
 default = ["native-tls", "test-registry"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 trust-dns = ["reqwest/trust-dns"]
 # This features is used by tests that use docker to create a registry
 test-registry = []


### PR DESCRIPTION
Expose a feature of the reqwest crate that allows to use the system certificates.
