### PR TITLE
Add support for compiling to wasm32 architecture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"
-tokio = { version = "1.21", features = ["macros", "fs"] }
+tokio = { version = "1.21", features = ["macros", "io-util"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 tracing = { version = "0.1", features = ['log'] }
 unicase = "2.6"


### PR DESCRIPTION
Most of the dependencies like reqwest already handle compilation for wasm32, so it is a matter of setting only the supported tokio features and guard some of the reqwest APIs that are not supported on wasm32.

The underlying motivation is to use sigstore on wasm32 architectures, but being able to work with OCI registries from WASM modules might come in handy as well.