### PR TITLE
Enhance client to push blobs, mount blobs, and push raw manifests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1002,7 +1002,11 @@ impl Client {
         digest: &str,
     ) -> Result<()> {
         let base_url = self.to_v2_blob_upload_url(image);
-        let url = format!("{}?mount={}&from={}", base_url, digest, source.repository());
+        let url = Url::parse_with_params(
+            &base_url,
+            &[("mount", digest), ("from", source.repository())],
+        )
+        .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))?;
 
         let res = RequestBuilderWrapper::from_client(self, |client| client.post(url.clone()))
             .apply_auth(image, RegistryOperation::Push)?

--- a/src/client.rs
+++ b/src/client.rs
@@ -1024,8 +1024,6 @@ impl Client {
     ///
     /// Returns pullable manifest URL
     pub async fn push_manifest(&self, image: &Reference, manifest: &OciManifest) -> Result<String> {
-        let url = self.to_v2_manifest_url(image);
-
         let mut headers = HeaderMap::new();
         let content_type = manifest.content_type();
         headers.insert("Content-Type", content_type.parse().unwrap());
@@ -2427,7 +2425,7 @@ mod test {
         let test_container = docker.run(registry_image());
         let port = test_container.get_host_port_ipv4(5000);
 
-        let mut c = Client::new(ClientConfig {
+        let c = Client::new(ClientConfig {
             protocol: ClientProtocol::HttpsExcept(vec![format!("localhost:{}", port)]),
             ..Default::default()
         });

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -61,6 +61,9 @@ pub enum OciDistributionError {
     /// Transparent wrapper around `reqwest::Error`
     #[error(transparent)]
     RequestError(#[from] reqwest::Error),
+    /// Cannot parse URL
+    #[error("Error parsing Url {0}")]
+    UrlParseError(String),
     /// HTTP Server error
     #[error("Server error: url {url}, code: {code}, message: {message}")]
     ServerError {


### PR DESCRIPTION
This is a rebased version of #63, which was automatically closed due to the history rewrite. I have addressed the PR feedback (see [here](https://github.com/krustlet/oci-distribution/pull/63#discussion_r1120745561) and [here](https://github.com/krustlet/oci-distribution/pull/63#discussion_r1122810246) for more info).