### PR TITLE
client: Fix failed to pull ubuntu image from docker.io

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -696,6 +696,7 @@ impl Client {
             if media_type != IMAGE_MANIFEST_MEDIA_TYPE
                 && media_type != OCI_IMAGE_MEDIA_TYPE
                 && media_type != IMAGE_MANIFEST_LIST_MEDIA_TYPE
+                && media_type != OCI_IMAGE_INDEX_MEDIA_TYPE
             {
                 return Err(OciDistributionError::UnsupportedMediaTypeError(media_type));
             }


### PR DESCRIPTION
Manifests list feature in `oci-distribution` is already implemented, default image in docker.io like busybox use `IMAGE_MANIFEST_LIST_MEDIA_TYPE`, but ubuntu image use `OCI_IMAGE_INDEX_MEDIA_TYPE`.

Fixes: #27