### PR TITLE
Change the visibility of `OciEnvelop.errors` to `pub`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -125,7 +125,8 @@ impl std::fmt::Display for OciError {
 /// A struct that holds a series of OCI errors
 #[derive(serde::Deserialize, Debug)]
 pub struct OciEnvelope {
-    pub(crate) errors: Vec<OciError>,
+    /// List of OCI registry errors
+    pub errors: Vec<OciError>,
 }
 
 impl std::fmt::Display for OciEnvelope {


### PR DESCRIPTION
The visibility of the registry error code (`OciErrorCode`) is `pub`, but there is no way to use it because the visibility of `OciEnvelop.errors` is `pub(crate)`.