### PR TITLE
Conversion between a Config and a ConfigFile

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -165,6 +165,15 @@ impl Config {
     }
 }
 
+impl TryFrom<Config> for ConfigFile {
+    type Error = crate::errors::OciDistributionError;
+
+    fn try_from(config: Config) -> Result<Self> {
+        let config_file: ConfigFile = serde_json::from_slice(&config.data)?;
+        Ok(config_file)
+    }
+}
+
 /// The OCI client connects to an OCI registry and fetches OCI images.
 ///
 /// An OCI registry is a container registry that adheres to the OCI Distribution

--- a/src/client.rs
+++ b/src/client.rs
@@ -169,7 +169,8 @@ impl TryFrom<Config> for ConfigFile {
     type Error = crate::errors::OciDistributionError;
 
     fn try_from(config: Config) -> Result<Self> {
-        let config_file: ConfigFile = serde_json::from_slice(&config.data)?;
+        let config = String::from_utf8(config.data)?;
+        let config_file: ConfigFile = serde_json::from_str(&config)?;
         Ok(config_file)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -169,8 +169,10 @@ impl TryFrom<Config> for ConfigFile {
     type Error = crate::errors::OciDistributionError;
 
     fn try_from(config: Config) -> Result<Self> {
-        let config = String::from_utf8(config.data)?;
-        let config_file: ConfigFile = serde_json::from_str(&config)?;
+        let config = String::from_utf8(config.data)
+            .map_err(|e| OciDistributionError::ConfigConversionError(e.to_string()))?;
+        let config_file: ConfigFile = serde_json::from_str(&config)
+            .map_err(|e| OciDistributionError::ConfigConversionError(e.to_string()))?;
         Ok(config_file)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -90,6 +90,9 @@ pub enum OciDistributionError {
     /// Versioned object: JSON deserialization error
     #[error("Failed to parse manifest: {0}")]
     VersionedParsingError(String),
+    #[error(transparent)]
+    /// Transparent wrapper around `std::string::FromUtf8Error`
+    FromUtf8(#[from] std::string::FromUtf8Error),
 }
 
 /// Helper type to declare `Result` objects that might return a `OciDistributionError`

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -90,9 +90,9 @@ pub enum OciDistributionError {
     /// Versioned object: JSON deserialization error
     #[error("Failed to parse manifest: {0}")]
     VersionedParsingError(String),
-    #[error(transparent)]
+    #[error("Failed to convert Config into ConfigFile: {0}")]
     /// Transparent wrapper around `std::string::FromUtf8Error`
-    FromUtf8(#[from] std::string::FromUtf8Error),
+    ConfigConversionError(String),
 }
 
 /// Helper type to declare `Result` objects that might return a `OciDistributionError`


### PR DESCRIPTION
This PR implements the TryFrom for a client::Config so that it can be parsed back into a ConfigFile.

This feature is useful when pulling images from a registry, so that the metadata recieved can be viewed.
