### PR TITLE
Update default `docker.io` registry

### DIFF
--- a/src/reference.rs
+++ b/src/reference.rs
@@ -108,7 +108,7 @@ impl Reference {
     pub fn resolve_registry(&self) -> &str {
         let registry = self.registry();
         match registry {
-            "docker.io" => "registry-1.docker.io",
+            "docker.io" => "index.docker.io",
             _ => registry,
         }
     }


### PR DESCRIPTION
This commit updates the default endpoint for DockerHub to be
`index.docker.io`. This is the default endpoint that the Docker CLI is
using.

Running `docker info`, this is the endpoint returned for the registry:

```
$ docker info | grep Registry
 Registry: https://index.docker.io/v1
```

This means we can now push references to
`index.docker.io/user/repo:tag`.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>