### PR TITLE
Fix: Expose HTTP errors when pulling layers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -768,6 +768,7 @@ impl Client {
             .into_request_builder()
             .send()
             .await?
+            .error_for_status()?
             .bytes_stream();
 
         while let Some(bytes) = stream.next().await {


### PR DESCRIPTION
I just ran into an issue exacerbated by a load balancer where the initial pull would succeed, but subsequent layer pulls would fail and return 0-bytes for random layers.

Turns out that using `request.byte_stream()` (or `request.bytes()`) will succeed regardless of HTTP status, so error responses would still "succeed" with no data returned.

This PR turns non-success responses into errors.