### PR TITLE
Higher-ranked lifetime error workaround

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -298,6 +298,7 @@ impl Client {
                     ))
                 }
             })
+            .boxed() // Workaround to rustc issue https://github.com/rust-lang/rust/issues/104382
             .buffer_unordered(self.config.max_concurrent_download)
             .try_collect()
             .await?;
@@ -365,6 +366,7 @@ impl Client {
                     Ok(())
                 }
             })
+            .boxed() // Workaround to rustc issue https://github.com/rust-lang/rust/issues/104382
             .buffer_unordered(self.config.max_concurrent_upload)
             .try_for_each(future::ok)
             .await?;


### PR DESCRIPTION
Workaround to a known issue of rustc: <https://github.com/rust-lang/rust/issues/104382>.

I encountered this issue when using this library with <https://github.com/seanmonstar/warp>. The error propagated from `oci-distribution` into my crate, outputting two hundred lines of error messages. Here is the horrible error messages from my project (<https://github.com/linyinfeng/oranc/pull/24/commits/d9076872dbb26a39d167ddff88cd9e04df44a7d4>, [cargo.log](https://github.com/krustlet/oci-distribution/files/12319923/cargo.log)).

After some bisect, debug, and search, I found that it is a known issue of rustc, and the workaround is simple.