### PR TITLE
Improved Push Logic

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -993,7 +993,7 @@ impl Client {
     /// Pushes the manifest for a specified image
     ///
     /// Returns pullable manifest URL
-    async fn push_manifest(&self, image: &Reference, manifest: &OciManifest) -> Result<String> {
+    pub async fn push_manifest(&self, image: &Reference, manifest: &OciManifest) -> Result<String> {
         let url = self.to_v2_manifest_url(image);
 
         let mut headers = HeaderMap::new();

--- a/src/client.rs
+++ b/src/client.rs
@@ -1412,20 +1412,15 @@ pub fn current_platform_resolver(manifests: &[ImageIndexEntry]) -> Option<String
 }
 
 /// The protocol that the client should use to connect
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ClientProtocol {
     #[allow(missing_docs)]
     Http,
     #[allow(missing_docs)]
+    #[default]
     Https,
     #[allow(missing_docs)]
     HttpsExcept(Vec<String>),
-}
-
-impl Default for ClientProtocol {
-    fn default() -> Self {
-        ClientProtocol::Https
-    }
 }
 
 impl ClientProtocol {
@@ -1468,7 +1463,6 @@ impl TryFrom<&HeaderValue> for BearerChallenge {
                     None
                 }
             })
-            .into_iter()
             .next()
             .ok_or_else(|| "Cannot find Bearer challenge".to_string())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,8 +133,7 @@ struct Empty {}
 /// Helper to deserialize a `map[string]struct{}` of golang
 fn hashset_from_str<'de, D: Deserializer<'de>>(d: D) -> Result<HashSet<String>, D::Error> {
     let res = <HashMap<String, Empty>>::deserialize(d)?
-        .into_iter()
-        .map(|(k, _)| k)
+        .into_keys()
         .collect();
     Ok(res)
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -51,10 +51,16 @@ pub enum OciManifest {
 
 impl OciManifest {
     /// Returns the appropriate content-type for each variant.
-    pub fn content_type(&self) -> &str {
+    pub fn content_type(&self) -> String {
         match self {
-            OciManifest::Image(_) => OCI_IMAGE_MEDIA_TYPE,
-            OciManifest::ImageIndex(_) => IMAGE_MANIFEST_LIST_MEDIA_TYPE,
+            OciManifest::Image(image) => image
+                .clone()
+                .media_type
+                .unwrap_or(String::from(OCI_IMAGE_MEDIA_TYPE)),
+            OciManifest::ImageIndex(image) => image
+                .clone()
+                .media_type
+                .unwrap_or(String::from(IMAGE_MANIFEST_LIST_MEDIA_TYPE)),
         }
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -53,11 +53,12 @@ impl OciManifest {
     /// Returns the appropriate content-type for each variant.
     pub fn content_type(&self) -> &str {
         match self {
-            OciManifest::Image(image) => image
-                .media_type.as_deref()
-                .unwrap_or(OCI_IMAGE_MEDIA_TYPE),
+            OciManifest::Image(image) => {
+                image.media_type.as_deref().unwrap_or(OCI_IMAGE_MEDIA_TYPE)
+            }
             OciManifest::ImageIndex(image) => image
-                .media_type.as_deref()
+                .media_type
+                .as_deref()
                 .unwrap_or(IMAGE_MANIFEST_LIST_MEDIA_TYPE),
         }
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -51,16 +51,14 @@ pub enum OciManifest {
 
 impl OciManifest {
     /// Returns the appropriate content-type for each variant.
-    pub fn content_type(&self) -> String {
+    pub fn content_type(&self) -> &str {
         match self {
             OciManifest::Image(image) => image
-                .clone()
-                .media_type
-                .unwrap_or(String::from(OCI_IMAGE_MEDIA_TYPE)),
+                .media_type.as_deref()
+                .unwrap_or(OCI_IMAGE_MEDIA_TYPE),
             OciManifest::ImageIndex(image) => image
-                .clone()
-                .media_type
-                .unwrap_or(String::from(IMAGE_MANIFEST_LIST_MEDIA_TYPE)),
+                .media_type.as_deref()
+                .unwrap_or(IMAGE_MANIFEST_LIST_MEDIA_TYPE),
         }
     }
 }
@@ -458,6 +456,7 @@ impl std::fmt::Display for Platform {
 #[cfg(test)]
 mod test {
     use super::*;
+
     const TEST_MANIFEST: &str = r#"{
         "schemaVersion": 2,
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",


### PR DESCRIPTION
* Added Media Type Extraction to OciManifest.content_type() to facilitate pushing of Docker Images
* Updated push_manifest to be public cause i believe that its generally useful for library consumers. [Usage Example](https://gitlab.com/rbbl/devops-tools/semtag/-/blob/main/src/main.rs?ref_type=heads)