### PR TITLE
fix: bring back workaround for rustc

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -364,6 +364,7 @@ impl Client {
                     Result::Ok(())
                 }
             })
+            .boxed() // Workaround to rustc issue https://github.com/rust-lang/rust/issues/104382
             .buffer_unordered(self.config.max_concurrent_upload)
             .try_for_each(future::ok)
             .await?;


### PR DESCRIPTION
Bring back the workaround required to circumvent https://github.com/rust-lang/rust/issues/104382

This was accidentally removed with 1c511f28c3338683162cb1f20ef218beb814ac65

CC @linyinfeng
