### PR TITLE
Create 0.11.0 relase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,15 @@ authors = [
 ]
 description = "An OCI implementation in Rust"
 edition = "2021"
-keywords = [
-  "oci",
-  "containers",
-]
+keywords = ["oci", "containers"]
 license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.10.0"
+version = "0.11.0"
 
 [badges]
-maintenance = {status = "actively-developed"}
+maintenance = { status = "actively-developed" }
 
 [features]
 default = ["native-tls", "test-registry"]
@@ -44,7 +41,10 @@ jwt = "0.16"
 lazy_static = "1.4"
 olpc-cjson = "0.1"
 regex = "1.6"
-reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "stream",
+] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"


### PR DESCRIPTION
What's Changed:

- client: Fix failed to pull ubuntu image from docker.io by @arronwy in https://github.com/krustlet/oci-distribution/pull/67
- Update rstest requirement from 0.16.0 to 0.17.0 by @dependabot in https://github.com/krustlet/oci-distribution/pull/70
- Bump actions/checkout from 3.3.0 to 3.4.0 by @dependabot in https://github.com/krustlet/oci-distribution/pull/69
- Bump actions/checkout from 3.4.0 to 3.5.0 by @dependabot in https://github.com/krustlet/oci-distribution/pull/73
- Change the visibility of `OciEnvelop.errors` to `pub` by @linyinfeng in https://github.com/krustlet/oci-distribution/pull/71
- Bump actions/checkout from 3.5.0 to 3.5.2 by @dependabot in https://github.com/krustlet/oci-distribution/pull/74
- make pushes concurrent and limit pull concurrency by @dicej in https://github.com/krustlet/oci-distribution/pull/72
- Update default `docker.io` registry by @radu-matei in https://github.com/krustlet/oci-distribution/pull/81
- Fix: Expose HTTP errors when pulling layers by @jsoverson in https://github.com/krustlet/oci-distribution/pull/82
- client: Return Stream for async_pull_blob API by @arronwy in https://github.com/krustlet/oci-distribution/pull/83
- chore(deps): Bump actions/checkout from 3.5.2 to 3.5.3 by @dependabot in https://github.com/krustlet/oci-distribution/pull/85
- fix(CI): address warnings of cargo deny by @flavio in https://github.com/krustlet/oci-distribution/pull/84
- consider ARCH as ppc64le when rust arch is powerpc64 by @Amulyam24 in https://github.com/krustlet/oci-distribution/pull/86
- chore(deps): Update rstest requirement from 0.17.0 to 0.18.1 by @dependabot in https://github.com/krustlet/oci-distribution/pull/88
- add optional artifactType to image manifest for oci v1.1 by @devigned in https://github.com/krustlet/oci-distribution/pull/89
- Higher-ranked lifetime error workaround by @linyinfeng in https://github.com/krustlet/oci-distribution/pull/90
- chore(deps): Bump actions/checkout from 3.5.3 to 3.6.0 by @dependabot in https://github.com/krustlet/oci-distribution/pull/91
- chore(deps): Bump actions/checkout from 3.6.0 to 4.0.0 by @dependabot in https://github.com/krustlet/oci-distribution/pull/92
- chore(deps): Bump actions/checkout from 4.0.0 to 4.1.0 by @dependabot in https://github.com/krustlet/oci-distribution/pull/94
- Improved Push Logic by @rbbl-dev in https://github.com/krustlet/oci-distribution/pull/93
- Update the configfile to match the oci v1 spec by @lswith in https://github.com/krustlet/oci-distribution/pull/77
- Conversion between a Config and a ConfigFile by @lswith in https://github.com/krustlet/oci-distribution/pull/76
- Enhance client to push blobs, mount blobs, and push raw manifests by @aochagavia in https://github.com/krustlet/oci-distribution/pull/66
- fix: bring back workaround for rustc by @flavio in https://github.com/krustlet/oci-distribution/pull/95
- implemented method to list tags by @rbbl-dev in https://github.com/krustlet/oci-distribution/pull/80
- feat(config.rs): add OS type for WASI Preview 1 by @vdice in https://github.com/krustlet/oci-distribution/pull/99
- chore(deps): Bump actions/checkout from 4.1.0 to 4.1.1 by @dependabot in https://github.com/krustlet/oci-distribution/pull/100
- chore(deps): Update testcontainers requirement from 0.14 to 0.15 by @dependabot in https://github.com/krustlet/oci-distribution/pull/96
- feat: return auth token from Client::auth by @mattarnoatibm in https://github.com/krustlet/oci-distribution/pull/105
