### PR TITLE
Fix crate version: 0.11 -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.11.0"
+version = "0.10.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
The crate version was already bumped. We never released 0.10, hence there's no need to jump straight from 0.9 to 0.11.
