### PR TITLE
Refactor auth - add re-auth mechanism

### DIFF
--- a/examples/get-manifest/main.rs
+++ b/examples/get-manifest/main.rs
@@ -85,7 +85,7 @@ pub async fn main() {
     let auth = build_auth(&reference, &cli);
 
     let client_config = build_client_config(&cli);
-    let mut client = Client::new(client_config);
+    let client = Client::new(client_config);
 
     let (manifest, _) = client
         .pull_manifest(&reference, &auth)

--- a/src/client.rs
+++ b/src/client.rs
@@ -534,6 +534,8 @@ impl Client {
         authentication: &RegistryAuth,
         operation: RegistryOperation,
     ) -> Result<Option<String>> {
+        self.store_auth_if_needed(image.resolve_registry(), authentication)
+            .await;
         // preserve old caching behavior
         match self._auth(image, authentication, operation).await {
             Ok(Some(RegistryTokenType::Bearer(token))) => {
@@ -1801,6 +1803,14 @@ mod test {
             .sign_with_key(&key)?
             .as_str()
             .to_string();
+
+        // we have to have it in the stored auth so we'll get to the token cache check.
+        client
+            .store_auth(
+                &Reference::try_from(HELLO_IMAGE_TAG)?.resolve_registry(),
+                RegistryAuth::Anonymous,
+            )
+            .await;
 
         client
             .tokens

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -59,7 +59,15 @@ pub enum RegistryOperation {
     Pull,
 }
 
-type CacheType = BTreeMap<(String, String, RegistryOperation), (RegistryTokenType, u64)>;
+// Types to allow better naming
+type Registry = String;
+type Repository = String;
+type TokenCacheKey = (Registry, Repository, RegistryOperation);
+type TokenExpiration = u64;
+type TokenCacheValue = (RegistryTokenType, TokenExpiration);
+
+// (registry, repository, scope) -> (token, expiration)
+type CacheType = BTreeMap<TokenCacheKey, TokenCacheValue>;
 
 #[derive(Default, Clone)]
 pub(crate) struct TokenCache {
@@ -68,12 +76,6 @@ pub(crate) struct TokenCache {
 }
 
 impl TokenCache {
-    pub(crate) fn new() -> Self {
-        TokenCache {
-            tokens: Arc::new(RwLock::new(BTreeMap::new())),
-        }
-    }
-
     pub(crate) async fn insert(
         &self,
         reference: &Reference,
@@ -157,9 +159,5 @@ impl TokenCache {
                 None
             }
         }
-    }
-
-    pub(crate) async fn contains_key(&self, reference: &Reference, op: RegistryOperation) -> bool {
-        self.get(reference, op).await.is_some()
     }
 }


### PR DESCRIPTION
Sorry about the spam!
This builds upon the other 2 PRs #109  #110 
Just out of comfort assuming if merged I'll work on it serially.
This adds logic to enable token re-creation when needed, and also making the auth API more fluent.
I had a situation where my token got expired mid-upload and there was no place to renew, and if I could break the API I'd have structured it a bit different, but I think is ok.