### PR TITLE
Implement Client::pull_manifest_raw

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -364,7 +364,7 @@ impl Client {
 
         validate_registry_response(status, &body, &url)?;
 
-        Ok(serde_json::from_str(&std::str::from_utf8(&body)?)?)
+        Ok(serde_json::from_str(std::str::from_utf8(&body)?)?)
     }
 
     /// Pull an image and return the bytes
@@ -856,10 +856,10 @@ impl Client {
 
         let text = std::str::from_utf8(&body)?;
 
-        self.validate_image_manifest(&text).await?;
+        self.validate_image_manifest(text).await?;
 
         debug!("Parsing response as Manifest: {}", &text);
-        let manifest = serde_json::from_str(&text)
+        let manifest = serde_json::from_str(text)
             .map_err(|e| OciDistributionError::ManifestParsingError(e.to_string()))?;
         Ok((manifest, digest))
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -736,8 +736,8 @@ impl Client {
     /// The client will check if it's already been authenticated and if
     /// not will attempt to do.
     ///
-    /// A Tuple is returned containing the plain text representation of the manifest
-    /// and the manifest content digest hash.
+    /// A Tuple is returned containing raw byte representation of the manifest
+    /// and the manifest content digest.
     pub async fn pull_manifest_raw(
         &self,
         image: &Reference,

--- a/src/client.rs
+++ b/src/client.rs
@@ -2762,7 +2762,7 @@ mod test {
     #[tokio::test]
     async fn test_raw_manifest_digest() {
         let _ = tracing_subscriber::fmt::try_init();
-        
+
         let c = Client::default();
 
         // pulling webassembly.azurecr.io/hello-wasm:v1@sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7

--- a/src/client.rs
+++ b/src/client.rs
@@ -360,11 +360,11 @@ impl Client {
             .send()
             .await?;
         let status = res.status();
-        let text = res.text().await?;
+        let body = res.bytes().await?;
 
-        validate_registry_response(status, &text, &url)?;
+        validate_registry_response(status, &body, &url)?;
 
-        Ok(serde_json::from_str(&text)?)
+        Ok(serde_json::from_str(&std::str::from_utf8(&body)?)?)
     }
 
     /// Pull an image and return the bytes
@@ -676,15 +676,15 @@ impl Client {
             let status = res.status();
             let headers = res.headers().clone();
             trace!(headers=?res.headers(), "Got Headers");
-            let text = res.text().await?;
-            validate_registry_response(status, &text, &url)?;
+            let body = res.bytes().await?;
+            validate_registry_response(status, &body, &url)?;
 
-            digest_header_value(headers, Some(&text.as_bytes()))
+            digest_header_value(headers, Some(&body))
         } else {
             let status = res.status();
             let headers = res.headers().clone();
-            let text = res.text().await?;
-            validate_registry_response(status, &text, &url)?;
+            let body = res.bytes().await?;
+            validate_registry_response(status, &body, &url)?;
 
             digest_header_value(headers, None)
         }
@@ -743,7 +743,7 @@ impl Client {
         image: &Reference,
         auth: &RegistryAuth,
         accepted_media_types: &[&str],
-    ) -> Result<(String, String)> {
+    ) -> Result<(Vec<u8>, String)> {
         self.store_auth_if_needed(image.resolve_registry(), auth)
             .await;
 
@@ -823,7 +823,7 @@ impl Client {
         &self,
         image: &Reference,
         accepted_media_types: &[&str],
-    ) -> Result<(String, String)> {
+    ) -> Result<(Vec<u8>, String)> {
         let url = self.to_v2_manifest_url(image);
         debug!("Pulling image manifest from {}", url);
 
@@ -836,13 +836,13 @@ impl Client {
             .await?;
         let headers = res.headers().clone();
         let status = res.status();
-        let text = res.text().await?;
+        let body = res.bytes().await?;
 
-        validate_registry_response(status, &text, &url)?;
+        validate_registry_response(status, &body, &url)?;
 
-        let digest = digest_header_value(headers, Some(&text.as_bytes()))?;
+        let digest = digest_header_value(headers, Some(&body))?;
 
-        Ok((text, digest))
+        Ok((body.to_vec(), digest))
     }
 
     /// Pull a manifest from the remote OCI Distribution service.
@@ -850,9 +850,11 @@ impl Client {
     /// If the connection has already gone through authentication, this will
     /// use the bearer token. Otherwise, this will attempt an anonymous pull.
     async fn _pull_manifest(&self, image: &Reference) -> Result<(OciManifest, String)> {
-        let (text, digest) = self
+        let (body, digest) = self
             ._pull_manifest_raw(image, MIME_TYPES_DISTRIBUTION_MANIFEST)
             .await?;
+
+        let text = std::str::from_utf8(&body)?;
 
         self.validate_image_manifest(&text).await?;
 
@@ -1414,7 +1416,7 @@ impl Client {
 /// The OCI spec technically does not allow any codes but 200, 500, 401, and 404.
 /// Obviously, HTTP servers are going to send other codes. This tries to catch the
 /// obvious ones (200, 4XX, 5XX). Anything else is just treated as an error.
-fn validate_registry_response(status: reqwest::StatusCode, text: &str, url: &str) -> Result<()> {
+fn validate_registry_response(status: reqwest::StatusCode, body: &[u8], url: &str) -> Result<()> {
     match status {
         reqwest::StatusCode::OK => Ok(()),
         reqwest::StatusCode::UNAUTHORIZED => Err(OciDistributionError::UnauthorizedError {
@@ -1426,6 +1428,7 @@ fn validate_registry_response(status: reqwest::StatusCode, text: &str, url: &str
             status,
         ))),
         s if s.is_client_error() => {
+            let text = std::str::from_utf8(body)?;
             // According to the OCI spec, we should see an error in the message body.
             let envelope = serde_json::from_str::<OciEnvelope>(text)?;
             Err(OciDistributionError::RegistryError {
@@ -1433,11 +1436,15 @@ fn validate_registry_response(status: reqwest::StatusCode, text: &str, url: &str
                 url: url.to_string(),
             })
         }
-        s => Err(OciDistributionError::ServerError {
-            code: s.as_u16(),
-            url: url.to_string(),
-            message: text.to_string(),
-        }),
+        s => {
+            let text = std::str::from_utf8(body)?;
+
+            Err(OciDistributionError::ServerError {
+                code: s.as_u16(),
+                url: url.to_string(),
+                message: text.to_string(),
+            })
+        }
     }
 }
 
@@ -2753,18 +2760,10 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "test-registry")]
     async fn test_raw_manifest_digest() {
-        let docker = clients::Cli::default();
-        let test_container = docker.run(registry_image());
-
         let _ = tracing_subscriber::fmt::try_init();
-        let port = test_container.get_host_port_ipv4(5000);
-
-        let c = Client::new(ClientConfig {
-            protocol: ClientProtocol::HttpsExcept(vec![format!("localhost:{}", port)]),
-            ..Default::default()
-        });
+        
+        let c = Client::default();
 
         // pulling webassembly.azurecr.io/hello-wasm:v1@sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7
         let image: Reference = HELLO_IMAGE_TAG_AND_DIGEST.parse().unwrap();
@@ -2782,7 +2781,7 @@ mod test {
             .expect("failed to pull manifest");
 
         // Compute the digest of the returned manifest text.
-        let digest = sha2::Sha256::digest(manifest.as_bytes());
+        let digest = sha2::Sha256::digest(manifest);
         let hex = format!("sha256:{:x}", digest);
 
         // Validate that the computed digest and the digest in the pulled reference match.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,9 @@ pub enum OciDistributionError {
     #[error(transparent)]
     /// Transparent wrapper around `serde_json::error::Error`
     JsonError(#[from] serde_json::error::Error),
+    /// Manifest is not valid UTF-8
+    #[error("Manifest is not valid UTF-8")]
+    ManifestEncodingError(#[from] std::str::Utf8Error),
     /// Manifest: JSON unmarshalling error
     #[error("Failed to parse manifest as Versioned object: {0}")]
     ManifestParsingError(String),


### PR DESCRIPTION
Implements `Client::pull_manifest_raw` for fetching the plain text representation of a manifest without deserializing it into an `OciManifest`.

This way the manifest can be pushed elsewhere while maintaining the digest value of the manifest which is otherwise subject to change following re-serialization of the `OciManifest` object.

### Asymmetry with `push_raw_manifest`
`push_manifest_raw` takes a `Vec<u8>`, while `pull_manifest_raw` returns the content as a `String`. I've chosen this route, since it allows us to still call `validate_registry_response` in `Client::_pull_manifest_raw` where the response status and manifest text is available for validation.

### Providing `accepted_media_types` when pulling raw manifests
Since `pull_manifest_raw` is specifically intended for fetching individual manifests for mirroring, I expect the caller to be traversing the tree of manifests manually and pushing/storing them elsewhere, and in that case they will have a very good idea of what kind of manifest they're likely to get back at each individual step.

### Deduplicating code
I've re-implemented `Client::_pull_manifest` in terms of `Client::_pull_manifest_raw` to reduce code duplication, so it now uses the raw function to get the text manifest, and then performs deserialization from there.

Closes #114 