### PR TITLE
Tag 0.11 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.10.0"
+version = "0.11.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
It has been a while since we published the last release. I think it's time for another minor release.

We have to do a minor release, instead of a patch one, because we introduced some breaking changes in the API.

## Changelog

### What's Changed

- client is now clonable and can be used in concurrent manner by @aviramha in https://github.com/krustlet/oci-distribution/pull/109
- fix(\*): Fixes our use of deprecated functions by @thomastaylor312 in https://github.com/krustlet/oci-distribution/pull/113
- Pull alternative urls by @seanyoung in https://github.com/krustlet/oci-distribution/pull/108
- Refactor auth - add re-auth mechanism by @aviramha in https://github.com/krustlet/oci-distribution/pull/111
- Implement Client::pull_manifest_raw by @MathiasPius in https://github.com/krustlet/oci-distribution/pull/115
- chore(deps): Bump actions/checkout from 4.1.1 to 4.1.2 by @dependabot in https://github.com/krustlet/oci-distribution/pull/117
- chore(deps): update reqwest and http by @flavio in https://github.com/krustlet/oci-distribution/pull/119

### New Contributors

- @aviramha made their first contribution in https://github.com/krustlet/oci-distribution/pull/109
- @thomastaylor312 made their first contribution in https://github.com/krustlet/oci-distribution/pull/113
- @seanyoung made their first contribution in https://github.com/krustlet/oci-distribution/pull/108
- @MathiasPius made their first contribution in https://github.com/krustlet/oci-distribution/pull/115

**Full Changelog**: https://github.com/krustlet/oci-distribution/compare/v0.10.0...v0.11.0
