### PR TITLE
ref(client): Debug, Eq, Hash, PartialEq for ImageLayer; convert annotations to BTreeMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ chrono = { version = "0.4.23", features = ["serde"] }
 futures-util = "0.3"
 http = "1.1"
 http-auth = { version = "0.1", default_features = false }
-itertools = "0.12.1"
 jwt = "0.16"
 lazy_static = "1.4"
 olpc-cjson = "0.1"
@@ -62,6 +61,7 @@ clap = { version = "4.0", features = ["derive"] }
 rstest = "0.18.1"
 docker_credential = "1.0"
 hmac = "0.12"
+itertools = "0.12.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3.3"
 testcontainers = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ chrono = { version = "0.4.23", features = ["serde"] }
 futures-util = "0.3"
 http = "1.1"
 http-auth = { version = "0.1", default_features = false }
+itertools = "0.12.1"
 jwt = "0.16"
 lazy_static = "1.4"
 olpc-cjson = "0.1"

--- a/examples/wasm/main.rs
+++ b/examples/wasm/main.rs
@@ -1,7 +1,7 @@
 use oci_distribution::{annotations, secrets::RegistryAuth, Client, Reference};
 
 use docker_credential::{CredentialRetrievalError, DockerCredential};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use tracing::{debug, warn};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -84,14 +84,14 @@ pub async fn main() {
             let auth = build_auth(&reference, &cli);
 
             let annotations = if annotations.is_empty() {
-                let mut values: HashMap<String, String> = HashMap::new();
+                let mut values: BTreeMap<String, String> = BTreeMap::new();
                 values.insert(
                     annotations::ORG_OPENCONTAINERS_IMAGE_TITLE.to_string(),
                     module.clone(),
                 );
                 Some(values)
             } else {
-                let mut values: HashMap<String, String> = HashMap::new();
+                let mut values: BTreeMap<String, String> = BTreeMap::new();
                 for annotation in annotations {
                     let tmp: Vec<_> = annotation.splitn(2, '=').collect();
                     if tmp.len() == 2 {

--- a/examples/wasm/push.rs
+++ b/examples/wasm/push.rs
@@ -4,7 +4,7 @@ use oci_distribution::{
     secrets::RegistryAuth,
     Client, Reference,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use tracing::info;
 
 pub(crate) async fn push_wasm(
@@ -12,7 +12,7 @@ pub(crate) async fn push_wasm(
     auth: &RegistryAuth,
     reference: &Reference,
     module: &str,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) {
     info!(?reference, ?module, "pushing wasm module");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,16 +23,15 @@ use futures_util::stream::{self, StreamExt, TryStreamExt};
 use futures_util::Stream;
 use http::HeaderValue;
 use http_auth::{parser::ChallengeParser, ChallengeRef};
-use itertools::Itertools;
 use olpc_cjson::CanonicalFormatter;
 use reqwest::header::HeaderMap;
 use reqwest::{RequestBuilder, Url};
 use serde::Deserialize;
 use serde::Serialize;
 use sha2::Digest;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::sync::Arc;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::RwLock;
@@ -88,7 +87,7 @@ pub struct TagResponse {
 }
 
 /// The data and media type for an image layer
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ImageLayer {
     /// The data of this layer
     pub data: Vec<u8>,
@@ -96,7 +95,7 @@ pub struct ImageLayer {
     pub media_type: String,
     /// This OPTIONAL property contains arbitrary metadata for this descriptor.
     /// This OPTIONAL property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules)
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 impl ImageLayer {
@@ -104,7 +103,7 @@ impl ImageLayer {
     pub fn new(
         data: Vec<u8>,
         media_type: String,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Self {
         ImageLayer {
             data,
@@ -115,34 +114,18 @@ impl ImageLayer {
 
     /// Constructs a new ImageLayer struct with provided data and
     /// media type application/vnd.oci.image.layer.v1.tar
-    pub fn oci_v1(data: Vec<u8>, annotations: Option<HashMap<String, String>>) -> Self {
+    pub fn oci_v1(data: Vec<u8>, annotations: Option<BTreeMap<String, String>>) -> Self {
         Self::new(data, IMAGE_LAYER_MEDIA_TYPE.to_string(), annotations)
     }
     /// Constructs a new ImageLayer struct with provided data and
     /// media type application/vnd.oci.image.layer.v1.tar+gzip
-    pub fn oci_v1_gzip(data: Vec<u8>, annotations: Option<HashMap<String, String>>) -> Self {
+    pub fn oci_v1_gzip(data: Vec<u8>, annotations: Option<BTreeMap<String, String>>) -> Self {
         Self::new(data, IMAGE_LAYER_GZIP_MEDIA_TYPE.to_string(), annotations)
     }
 
     /// Helper function to compute the sha256 digest of an image layer
     pub fn sha256_digest(&self) -> String {
         sha256_digest(&self.data)
-    }
-}
-
-/// Implementing Hash to enable determining uniqueness
-/// eg via https://docs.rs/itertools/latest/itertools/structs/struct.Unique.html
-impl Hash for ImageLayer {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.data.hash(state);
-        self.media_type.hash(state);
-        if let Some(annotations) = self.annotations.clone() {
-            let sorted = annotations.iter().sorted();
-            for (k, v) in sorted {
-                k.hash(state);
-                v.hash(state);
-            }
-        }
     }
 }
 
@@ -155,7 +138,7 @@ pub struct Config {
     pub media_type: String,
     /// This OPTIONAL property contains arbitrary metadata for this descriptor.
     /// This OPTIONAL property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules)
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 impl Config {
@@ -163,7 +146,7 @@ impl Config {
     pub fn new(
         data: Vec<u8>,
         media_type: String,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Self {
         Config {
             data,
@@ -174,7 +157,7 @@ impl Config {
 
     /// Constructs a new Config struct with provided data and
     /// media type application/vnd.oci.image.config.v1+json
-    pub fn oci_v1(data: Vec<u8>, annotations: Option<HashMap<String, String>>) -> Self {
+    pub fn oci_v1(data: Vec<u8>, annotations: Option<BTreeMap<String, String>>) -> Self {
         Self::new(data, IMAGE_CONFIG_MEDIA_TYPE.to_string(), annotations)
     }
 
@@ -182,7 +165,7 @@ impl Config {
     /// media type `application/vnd.oci.image.config.v1+json`
     pub fn oci_v1_from_config_file(
         config_file: ConfigFile,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<Self> {
         let data = serde_json::to_vec(&config_file)?;
         Ok(Self::new(
@@ -2950,12 +2933,14 @@ mod test {
 
     #[tokio::test]
     async fn test_hashable_image_layer() {
+        use itertools::Itertools;
+
         // First two should be identical; others differ
         let image_layers = Vec::from([
             ImageLayer {
                 data: Vec::from([0, 1, 2, 3]),
                 media_type: "media_type".to_owned(),
-                annotations: Some(HashMap::from([
+                annotations: Some(BTreeMap::from([
                     ("0".to_owned(), "1".to_owned()),
                     ("2".to_owned(), "3".to_owned()),
                 ])),
@@ -2963,7 +2948,7 @@ mod test {
             ImageLayer {
                 data: Vec::from([0, 1, 2, 3]),
                 media_type: "media_type".to_owned(),
-                annotations: Some(HashMap::from([
+                annotations: Some(BTreeMap::from([
                     ("2".to_owned(), "3".to_owned()),
                     ("0".to_owned(), "1".to_owned()),
                 ])),
@@ -2971,7 +2956,7 @@ mod test {
             ImageLayer {
                 data: Vec::from([0, 1, 2, 3]),
                 media_type: "different_media_type".to_owned(),
-                annotations: Some(HashMap::from([
+                annotations: Some(BTreeMap::from([
                     ("0".to_owned(), "1".to_owned()),
                     ("2".to_owned(), "3".to_owned()),
                 ])),
@@ -2979,7 +2964,7 @@ mod test {
             ImageLayer {
                 data: Vec::from([0, 1, 2]),
                 media_type: "media_type".to_owned(),
-                annotations: Some(HashMap::from([
+                annotations: Some(BTreeMap::from([
                     ("0".to_owned(), "1".to_owned()),
                     ("2".to_owned(), "3".to_owned()),
                 ])),
@@ -2987,7 +2972,7 @@ mod test {
             ImageLayer {
                 data: Vec::from([0, 1, 2, 3]),
                 media_type: "media_type".to_owned(),
-                annotations: Some(HashMap::from([
+                annotations: Some(BTreeMap::from([
                     ("1".to_owned(), "0".to_owned()),
                     ("2".to_owned(), "3".to_owned()),
                 ])),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,5 +1,5 @@
 //! OCI Manifest
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::{
     client::{Config, ImageLayer},
@@ -113,7 +113,7 @@ pub struct OciImageManifest {
     /// MUST either be absent or be an empty map."
     /// TO accomodate either, this is optional.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 impl Default for OciImageManifest {
@@ -137,7 +137,7 @@ impl OciImageManifest {
     pub fn build(
         layers: &[ImageLayer],
         config: &Config,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Self {
         let mut manifest = OciImageManifest::default();
 
@@ -276,7 +276,7 @@ pub struct OciDescriptor {
     /// This OPTIONAL property MUST use the annotation rules.
     /// <https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules>
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 impl std::fmt::Display for OciDescriptor {
@@ -334,7 +334,7 @@ pub struct OciImageIndex {
     /// MUST either be absent or be an empty map."
     /// TO accomodate either, this is optional.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 /// The manifest entry of an `ImageIndex`.
@@ -375,7 +375,7 @@ pub struct ImageIndexEntry {
     /// This OPTIONAL property contains arbitrary metadata for the image index.
     /// This OPTIONAL property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 impl std::fmt::Display for ImageIndexEntry {


### PR DESCRIPTION
- Update ImageLayer to derive Debug, Eq, Hash and PartialEq traits
- **_Breaking_**: Convert annotations from a HashMap to a BTreeMap per https://github.com/krustlet/oci-distribution/pull/121#discussion_r1544777159, so that we don't need a custom Hash impl for ImageLayer

Changeset motivated by the need to differentiate and deduplicate collections of ImageLayers.