### PR TITLE
feat(client/token_cache): allow configuration of default token expiration

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -51,6 +51,9 @@ pub const DEFAULT_MAX_CONCURRENT_UPLOAD: usize = 16;
 /// Default value for `ClientConfig::max_concurrent_download`
 pub const DEFAULT_MAX_CONCURRENT_DOWNLOAD: usize = 16;
 
+/// Default value for `ClientConfig:default_token_expiration_secs`
+pub const DEFAULT_TOKEN_EXPIRATION_SECS: usize = 60;
+
 /// The data for an image or module.
 #[derive(Clone)]
 pub struct ImageData {
@@ -259,8 +262,11 @@ impl TryFrom<ClientConfig> for Client {
             client_builder = client_builder.add_root_certificate(cert);
         }
 
+        let mut tokens = TokenCache::default();
+        tokens.default_expiration_secs = config.default_token_expiration_secs;
         Ok(Self {
             config: Arc::new(config),
+            tokens,
             client: client_builder.build()?,
             push_chunk_size: PUSH_CHUNK_MAX_SIZE,
             ..Default::default()
@@ -271,10 +277,13 @@ impl TryFrom<ClientConfig> for Client {
 impl Client {
     /// Create a new client with the supplied config
     pub fn new(config: ClientConfig) -> Self {
+        let mut tokens = TokenCache::default();
+        tokens.default_expiration_secs = config.default_token_expiration_secs;
         Client::try_from(config).unwrap_or_else(|err| {
             warn!("Cannot create OCI client from config: {:?}", err);
             warn!("Creating client with default configuration");
             Self {
+                tokens,
                 push_chunk_size: PUSH_CHUNK_MAX_SIZE,
                 ..Default::default()
             }
@@ -1604,6 +1613,12 @@ pub struct ClientConfig {
     ///
     /// This defaults to [`DEFAULT_MAX_CONCURRENT_DOWNLOAD`].
     pub max_concurrent_download: usize,
+
+    /// Default token expiration in seconds, to use when the token claim
+    /// doesn't provide a value.
+    ///
+    /// This defaults to [`DEFAULT_TOKEN_EXPIRATION_SECS`].
+    pub default_token_expiration_secs: usize,
 }
 
 impl Default for ClientConfig {
@@ -1617,6 +1632,7 @@ impl Default for ClientConfig {
             platform_resolver: Some(Box::new(current_platform_resolver)),
             max_concurrent_upload: DEFAULT_MAX_CONCURRENT_UPLOAD,
             max_concurrent_download: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
+            default_token_expiration_secs: DEFAULT_TOKEN_EXPIRATION_SECS,
         }
     }
 }

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -1,4 +1,3 @@
-use crate::client::DEFAULT_TOKEN_EXPIRATION_SECS;
 use crate::reference::Reference;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -80,16 +79,14 @@ pub(crate) struct TokenCache {
     pub default_expiration_secs: usize,
 }
 
-impl Default for TokenCache {
-    fn default() -> Self {
-        Self {
-            tokens: Arc::default(),
-            default_expiration_secs: DEFAULT_TOKEN_EXPIRATION_SECS,
+impl TokenCache {
+    pub(crate) fn new(default_expiration_secs: usize) -> Self {
+        TokenCache {
+            tokens: Arc::new(RwLock::new(BTreeMap::new())),
+            default_expiration_secs,
         }
     }
-}
 
-impl TokenCache {
     pub(crate) async fn insert(
         &self,
         reference: &Reference,

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -1,3 +1,4 @@
+use crate::client::DEFAULT_TOKEN_EXPIRATION_SECS;
 use crate::reference::Reference;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -71,10 +72,21 @@ struct TokenCacheValue {
     expiration: u64,
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub(crate) struct TokenCache {
     // (registry, repository, scope) -> (token, expiration)
     tokens: Arc<RwLock<BTreeMap<TokenCacheKey, TokenCacheValue>>>,
+    /// Default token expiration in seconds, to use when claim doesn't specify a value
+    pub default_expiration_secs: usize,
+}
+
+impl Default for TokenCache {
+    fn default() -> Self {
+        Self {
+            tokens: Arc::default(),
+            default_expiration_secs: DEFAULT_TOKEN_EXPIRATION_SECS,
+        }
+    }
 }
 
 impl TokenCache {
@@ -109,8 +121,8 @@ impl TokenCache {
                                 .duration_since(UNIX_EPOCH)
                                 .expect("Time went backwards")
                                 .as_secs();
-                            let expiration = epoch + 60;
-                            debug!(?token, "Cannot extract expiration from token's claims, assuming a 60 seconds validity");
+                            let expiration = epoch + self.default_expiration_secs as u64;
+                            debug!(?token, "Cannot extract expiration from token's claims, assuming a {} seconds validity", self.default_expiration_secs);
                             expiration
                         },
                         Err(error) => {


### PR DESCRIPTION
- Updates to allow configuration of the default token expiration value, via ClientConfig

Open to suggestions on how best to pipe this through where it needs to be.  I noticed `TokenCache` no longer has a `new()` function, hence the creation of `TokenCache::default()` and then amending the attribute.