### PR TITLE
Create new LayerDescriptor for pulling blobs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -145,8 +145,8 @@ impl AsLayerDescriptor for OciDescriptor {
     }
 }
 
-impl<'a> AsLayerDescriptor for &'a OciDescriptor {
-    fn as_layer_descriptor(&self) -> LayerDescriptor<'a> {
+impl AsLayerDescriptor for &OciDescriptor {
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
         LayerDescriptor {
             digest: &self.digest,
             urls: &self.urls,
@@ -157,6 +157,15 @@ impl<'a> AsLayerDescriptor for &'a OciDescriptor {
 impl AsLayerDescriptor for LayerDescriptor<'_> {
     fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
         self.into()
+    }
+}
+
+impl AsLayerDescriptor for &LayerDescriptor<'_> {
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
+        LayerDescriptor {
+            digest: self.digest,
+            urls: self.urls,
+        }
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1092,8 +1092,9 @@ impl Client {
     pub async fn pull_blob_stream(
         &self,
         image: &Reference,
-        layer: &LayerDescriptor<'_>,
+        layer: impl AsLayerDescriptor,
     ) -> Result<impl Stream<Item = std::result::Result<bytes::Bytes, std::io::Error>>> {
+        let layer = layer.as_layer_descriptor();
         let url = self.to_v2_blob_url(image.resolve_registry(), image.repository(), layer.digest);
 
         let mut response = RequestBuilderWrapper::from_client(self, |client| client.get(&url))
@@ -2556,7 +2557,7 @@ mod test {
             let layer0 = &manifest.layers[0];
 
             let layer_stream = c
-                .pull_blob_stream(&reference, &layer0.into())
+                .pull_blob_stream(&reference, layer0)
                 .await
                 .expect("failed to pull blob stream");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,33 +94,6 @@ pub struct LayerDescriptor<'a> {
     pub urls: &'a Option<Vec<String>>,
 }
 
-impl<'a> From<&'a LayerDescriptor<'a>> for LayerDescriptor<'a> {
-    fn from(descriptor: &'a LayerDescriptor<'a>) -> Self {
-        LayerDescriptor {
-            digest: descriptor.digest,
-            urls: descriptor.urls,
-        }
-    }
-}
-
-impl<'a> From<&'a str> for LayerDescriptor<'a> {
-    fn from(digest: &'a str) -> Self {
-        LayerDescriptor {
-            digest,
-            urls: &None,
-        }
-    }
-}
-
-impl<'a> From<&'a OciDescriptor> for LayerDescriptor<'a> {
-    fn from(descriptor: &'a OciDescriptor) -> Self {
-        LayerDescriptor {
-            digest: &descriptor.digest,
-            urls: &descriptor.urls,
-        }
-    }
-}
-
 /// A trait for converting any type into a [`LayerDescriptor`]
 pub trait AsLayerDescriptor {
     /// Convert the type to a LayerDescriptor reference
@@ -136,27 +109,12 @@ impl AsLayerDescriptor for &str {
     }
 }
 
-impl AsLayerDescriptor for OciDescriptor {
-    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
-        LayerDescriptor {
-            digest: &self.digest,
-            urls: &self.urls,
-        }
-    }
-}
-
 impl AsLayerDescriptor for &OciDescriptor {
     fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
         LayerDescriptor {
             digest: &self.digest,
             urls: &self.urls,
         }
-    }
-}
-
-impl AsLayerDescriptor for LayerDescriptor<'_> {
-    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
-        self.into()
     }
 }
 


### PR DESCRIPTION
The old `OciDescriptor` has too many fields, which maybe aren't available when trying to pull a blob with only the digest. In the past you only needed the digest as string, but the optional urls field was added (in #108). But all other fields of the `OciDescriptor` aren't required when pulling a blob, but are required by the struct. The `LayerDescriptor` struct now has only the fields which are used for pulling.

This is a breaking change, as it changes the signature of the pull methods. But with this it is now possible to pull a blob with only the digest as a `&str` again.