### PR TITLE
feat(client): allow to set read_timeout and connect_timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ jwt = "0.16"
 lazy_static = "1.4"
 olpc-cjson = "0.1"
 regex = "1.6"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.12.4", default-features = false, features = [
   "json",
   "stream",
 ] }


### PR DESCRIPTION
Allow to set `read_timeout` and `connect_timeout` on the underlying client. Otherwise the pull will just hang forever if you have an unstable connection and there was an interruption.

I wasn't sure if it would be useful to set some defaults here, but decided against it, because there was no timeout before (so no change for existing implementations) and there is also no timeout set in the reqwest client by default. And I also wasn't sure what useful defaults would be (since that maybe depends on your connection?). But let me know if you want me to set a default value for these.