### PR TITLE
fix(deny): Fixes license issues with deny check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,10 +16,10 @@ default = "deny"
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     "LicenseRef-ring",
-    "LicenseRef-webpki",
     "LicenseRef-rustls-webpki",
     "MPL-2.0",
     "Unicode-DFS-2016",
+    "Unicode-3.0"
 ]
 
 deny = [
@@ -32,13 +32,6 @@ name = "ring"
 expression = "LicenseRef-ring"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 },
-]
-
-[[licenses.clarify]]
-name = "webpki"
-expression = "LicenseRef-webpki"
-license-files = [
-    { path = "LICENSE", hash = 0x001c7e6c },
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
After running a cargo update, some of the derive crates used by testcontainers (a dev dependency) are pulling in unicode parsing with the unicode-3.0 license which is the most recent.

As we already had a unicode exception in and since it is an OSI approved license, we should be ok here