### PR TITLE
chore: prepare the 0.16.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "Apache-2.0"
 name = "oci-client"
 readme = "README.md"
 repository = "https://github.com/oras-project/rust-oci-client"
-version = "0.15.0"
+version = "0.16.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Prepare for a new release.
