### PR TITLE
Remove unnecessary crypto features from jsonwebtoken dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["rustls-tls", "test-registry"]
-native-tls = ["reqwest/native-tls", "jsonwebtoken/rust_crypto"]
-rustls-tls = ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls"]
 hickory-dns = ["reqwest/hickory-dns"]
 # This features is used by tests that use docker to create a registry
 test-registry = []
@@ -64,6 +64,7 @@ clap = { version = "4.5", features = ["derive"] }
 rstest = "0.26"
 docker_credential = "1.3"
 hmac = "0.12"
+jsonwebtoken = { version = "10.2", features = ["rust_crypto"] }
 itertools = "0.14"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3.21"


### PR DESCRIPTION
The only production usage of jsonwebtoken is `dangerous::insecure_decode` in token_cache.rs, which does not require a crypto backend. The `jsonwebtoken::encode` call (which needs HMAC) is only used in tests.

Remove `jsonwebtoken/aws_lc_rs` from the `rustls-tls` feature and `jsonwebtoken/rust_crypto` from `native-tls`, and move jsonwebtoken with `rust_crypto` to dev-dependencies for tests.

This avoids pulling in aws-lc-sys (which contains C code that fails to cross-compile to macOS 11.3 targets) and the `rsa` crate (which has a known vulnerability) for users of this library.