### PR TITLE
Fix data loss in pull_blob due to missing flush

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1167,6 +1167,9 @@ impl Client {
             out.write_all(&bytes).await?;
         }
 
+        // Ensure all buffered writes are flushed before returning.
+        out.flush().await?;
+
         if let Some((mut digester, expected)) = maybe_header_digester.take() {
             let digest = digester.finalize();
 


### PR DESCRIPTION
## Summary

`pull_blob` takes ownership of the `AsyncWrite` writer but never calls `flush()` before returning. With `tokio::fs::File`, `poll_write` returns `Ready(Ok(n))` after buffering data internally — before the blocking write completes. When the file is dropped without flushing, the last write(s) may still be in-flight, leaving truncated or empty files on disk.

Digest verification is unaffected because it operates on the in-memory bytes passed to `write_all`, not on what the filesystem actually contains.

Since `pull_blob` consumes the writer by value, callers have no opportunity to flush after the call returns.

## Fix

Add `out.flush().await?` after the write loop. For already-unbuffered writers this is a no-op.

## Reproduction

The bug is non-deterministic and manifests under concurrent I/O load (e.g. pulling multiple blobs in parallel). Observed as `tar` extraction failures ("failed to fill whole buffer") on files that appear as 0 bytes on disk despite passing SHA-256 verification.