### PR TITLE
fix: do not dump sensitive data in debug mode

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -805,7 +805,7 @@ impl Client {
         match auth_res.status() {
             reqwest::StatusCode::OK => {
                 let text = auth_res.text().await?;
-                debug!("Received response from auth request: {}", text);
+                debug!("Received response from auth request");
                 let token: RegistryToken = serde_json::from_str(&text)
                     .map_err(|e| OciDistributionError::RegistryTokenDecodeError(e.to_string()))?;
                 debug!("Successfully authorized for image '{:?}'", image);

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,7 +1,9 @@
 //! Types for working with registry access secrets
 
+use std::fmt;
+
 /// A method for authenticating to a registry
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub enum RegistryAuth {
     /// Access the registry anonymously
     Anonymous,
@@ -9,6 +11,20 @@ pub enum RegistryAuth {
     Basic(String, String),
     /// Access the registry using Bearer token authentication
     Bearer(String),
+}
+
+impl fmt::Debug for RegistryAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RegistryAuth::Anonymous => write!(f, "Anonymous"),
+            RegistryAuth::Basic(username, _) => f
+                .debug_tuple("Basic")
+                .field(username)
+                .field(&"<redacted>")
+                .finish(),
+            RegistryAuth::Bearer(_) => f.debug_tuple("Bearer").field(&"<redacted>").finish(),
+        }
+    }
 }
 
 pub(crate) trait Authenticable {

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -178,7 +178,7 @@ fn parse_expiration_from_jwt(token_str: &str, default_expiration_secs: usize) ->
                         .expect("Time went backwards")
                         .as_secs();
                     let expiration = epoch + default_expiration_secs as u64;
-                    debug!(?token, "Cannot extract expiration from token's claims, assuming a {} seconds validity", default_expiration_secs);
+                    debug!("Cannot extract expiration from token's claims, assuming a {} seconds validity", default_expiration_secs);
                     expiration
                 }
             };


### PR DESCRIPTION
Do not print registry's auth token and registry password when running in debug mode.

Fixes https://github.com/oras-project/rust-oci-client/issues/254
