### PR TITLE
chore: update cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,6 @@
 [advisories]
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa side channel attack, no fix exists yet" },
-    { id = "RUSTSEC-2026-0118", reason = "transitive dependency of reqwest, waiting for reqwest upgrade" },
-    { id = "RUSTSEC-2026-0119", reason = "transitive dependency of reqwest, waiting for reqwest upgrade" },
 ]
 
 [licenses]


### PR DESCRIPTION
The reqwest crate tagged a new version that addresses the security issues.

We can get rid of the exceptions inside of cargo deny configuration.
