### PR TITLE
fix: URL-encode artifactType in pull_referrers query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ jsonwebtoken = { version = "10.3", default-features = false }
 lazy_static = "1.4"
 oci-spec = "0.9"
 olpc-cjson = "0.1"
-percent-encoding = "2.3"
 regex = "1.11"
 reqwest = { version = "0.13", default-features = false, features = [
   "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ jsonwebtoken = { version = "10.3", default-features = false }
 lazy_static = "1.4"
 oci-spec = "0.9"
 olpc-cjson = "0.1"
+percent-encoding = "2.3"
 regex = "1.11"
 reqwest = { version = "0.13", default-features = false, features = [
   "json",

--- a/src/client.rs
+++ b/src/client.rs
@@ -1986,36 +1986,39 @@ impl Client {
         )
     }
 
-    /// Convert a Reference to a v2 manifest URL.
+    /// Convert a Reference to a v2 referrers URL.
     fn to_v2_referrers_url(
         &self,
         reference: &Reference,
         artifact_type: Option<&str>,
     ) -> Result<String> {
+        let digest = reference.digest().ok_or_else(|| {
+            OciDistributionError::GenericError(Some(
+                "Getting referrers for a tag is not supported".into(),
+            ))
+        })?;
+
         let registry = reference.resolve_registry();
-        Ok(format!(
-            "{scheme}://{registry}/v2/{repository}/referrers/{reference}{at}",
+        let base = format!(
+            "{scheme}://{registry}",
             scheme = self.config.protocol.scheme_for(registry),
-            repository = reference.repository(),
-            reference = if let Some(digest) = reference.digest() {
-                digest
-            } else {
-                return Err(OciDistributionError::GenericError(Some(
-                    "Getting referrers for a tag is not supported".into(),
-                )));
-            },
-            at = artifact_type
-                .map(|at| {
-                    format!(
-                        "?artifactType={}",
-                        percent_encoding::utf8_percent_encode(
-                            at,
-                            percent_encoding::NON_ALPHANUMERIC
-                        )
-                    )
-                })
-                .unwrap_or_default(),
-        ))
+        );
+        let mut url =
+            Url::parse(&base).map_err(|e| OciDistributionError::UrlParseError(e.to_string()))?;
+        url.path_segments_mut()
+            .map_err(|_| {
+                OciDistributionError::GenericError(Some(
+                    "cannot build referrers URL: base URL is cannot-be-a-base".into(),
+                ))
+            })?
+            .push("v2")
+            .extend(reference.repository().split('/'))
+            .push("referrers")
+            .push(digest);
+        if let Some(at) = artifact_type {
+            url.query_pairs_mut().append_pair("artifactType", at);
+        }
+        Ok(url.into())
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2005,7 +2005,15 @@ impl Client {
                 )));
             },
             at = artifact_type
-                .map(|at| format!("?artifactType={at}"))
+                .map(|at| {
+                    format!(
+                        "?artifactType={}",
+                        percent_encoding::utf8_percent_encode(
+                            at,
+                            percent_encoding::NON_ALPHANUMERIC
+                        )
+                    )
+                })
                 .unwrap_or_default(),
         ))
     }
@@ -2690,6 +2698,26 @@ mod test {
         assert_eq!(
             c.to_catalog_url(&image),
             "https://docker.mirror.io/v2/_catalog"
+        );
+    }
+
+    #[test]
+    fn test_to_v2_referrers_url() {
+        let image = Reference::try_from(HELLO_IMAGE_DIGEST).expect("failed to parse reference");
+        let c = Client::default();
+
+        // No filter: no query string.
+        assert_eq!(
+            c.to_v2_referrers_url(&image, None).unwrap(),
+            "https://webassembly.azurecr.io/v2/hello-wasm/referrers/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7"
+        );
+
+        // With filter: the artifactType value is percent-encoded. The `+` in `+json`
+        // media types must become `%2B`, otherwise standard query-string decoding turns
+        // it into a space and the registry filter matches nothing.
+        assert_eq!(
+            c.to_v2_referrers_url(&image, Some("application/spdx+json")).unwrap(),
+            "https://webassembly.azurecr.io/v2/hello-wasm/referrers/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7?artifactType=application%2Fspdx%2Bjson"
         );
     }
 


### PR DESCRIPTION
Fixes #264

`Client::to_v2_referrers_url` interpolated the `artifactType` filter into the
query string verbatim. Standard query-string decoding treats `+` as a space, so
`+json`/`+xml`/`+yaml` media types (SBOMs, signatures, attestations) reached the
registry mangled and the filter matched nothing — see #264 for full context and
reproduction.

This percent-encodes the value with `NON_ALPHANUMERIC` before interpolating, and
promotes `percent-encoding` to a direct dependency (already present transitively
via `reqwest`). The tag-schema fallback is unaffected — it filters client-side by
direct string comparison, not via the URL.

Adds `test_to_v2_referrers_url` covering the `+json` encoding case and the
no-filter case. `cargo test`, `cargo fmt --check`, and
`cargo clippy --all-targets -- -D warnings` all pass locally.

---

*Assisted by: Claude Code (Opus 4.8)*
