### PR TITLE
feat(token_cache): allow programmatic access to the client token cache

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -277,7 +277,8 @@ pub struct Client {
     config: Arc<ClientConfig>,
     // Registry -> RegistryAuth
     auth_store: Arc<RwLock<HashMap<String, RegistryAuth>>>,
-    tokens: TokenCache,
+    /// Token cache for the client
+    pub tokens: TokenCache,
     client: reqwest::Client,
     push_chunk_size: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub(crate) mod digest;
 pub mod errors;
 pub mod manifest;
 pub mod secrets;
-mod token_cache;
+pub mod token_cache;
 
 #[doc(inline)]
 pub use client::Client;

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -1,3 +1,5 @@
+//! Token cache for OCI registry authentication
+
 use oci_spec::distribution::Reference;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -11,9 +13,17 @@ use tracing::{debug, warn};
 #[derive(Deserialize, Clone)]
 #[serde(untagged)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum RegistryToken {
-    Token { token: String },
-    AccessToken { access_token: String },
+pub enum RegistryToken {
+    /// Token value
+    Token {
+        /// The string value of the token
+        token: String,
+    },
+    /// AccessToken value
+    AccessToken {
+        /// The string value of the access_token
+        access_token: String,
+    },
 }
 
 impl fmt::Debug for RegistryToken {
@@ -32,16 +42,21 @@ impl fmt::Debug for RegistryToken {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum RegistryTokenType {
+/// Type of registry auth token
+pub enum RegistryTokenType {
+    /// Bearer auth token type
     Bearer(RegistryToken),
+    /// Basic auth token type
     Basic(String, String),
 }
 
 impl RegistryToken {
+    /// Returns the bearer token in a form suitable to use for an Authorization header
     pub fn bearer_token(&self) -> String {
         format!("Bearer {}", self.token())
     }
 
+    /// Returns the token value
     pub fn token(&self) -> &str {
         match self {
             RegistryToken::Token { token } => token,
@@ -77,7 +92,8 @@ struct TokenCacheValue {
 }
 
 #[derive(Clone)]
-pub(crate) struct TokenCache {
+/// A cache to hold authentication tokens
+pub struct TokenCache {
     // (registry, repository, scope) -> (token, expiration)
     tokens: Arc<RwLock<BTreeMap<TokenCacheKey, TokenCacheValue>>>,
     /// Default token expiration in seconds, to use when claim doesn't specify a value
@@ -92,7 +108,8 @@ impl TokenCache {
         }
     }
 
-    pub(crate) async fn insert(
+    /// Insert a token corresponding to reference and operation keys
+    pub async fn insert(
         &self,
         reference: &Reference,
         op: RegistryOperation,


### PR DESCRIPTION
The goal here is to allow programmatic access to a client's token cache, specifically/only to `insert` a token into the cache for use with subsequent registry authentication.  An applicable scenario is for proxied OCI registries wherein a bearer token valid for a generic deployment environment can also be used to authenticate with the proxy layer for OCI push/pull operations, etc.  Hence, when a user has an auth token valid both for the deployment environment and registry proxy, this token can be added to this OCI client's cache and used for OCI operations.

The current approach to achieve the goal here in this PR is to update visibility of the token cache and allow calling `insert`.  Definitely open to adjusting approach if there is a preferred alternate that can still support scenarios above.