### PR TITLE
ci: proc-macro-error2 is no longer maintained, update cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa side channel attack, no fix exists yet" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is no longer maintained. This is a dependency of oci-spec crate" },
 ]
 
 [licenses]


### PR DESCRIPTION
proc-macro-error2 is no longer maintained. This is a dependency of oci-spec crate.

Update cargo deny configuration to ignore that until a solution is found by oci-spec.
